### PR TITLE
Exclude single use codes and QRs from BeamClaim type when not authenticated.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": false,
+    "prefer-stable": true,
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "dev-master",
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-bcmath": "*",
         "ext-json": "*",
         "ext-openssl": "*",
-        "enjin/platform-core": "dev-feature/pla-1081/authorizable-type-fields",
+        "enjin/platform-core": "*",
         "phrity/websocket": "^1.0",
         "rebing/graphql-laravel": "^9.0.0-rc1",
         "spatie/laravel-package-tools": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-bcmath": "*",
         "ext-json": "*",
         "ext-openssl": "*",
-        "enjin/platform-core": "*",
+        "enjin/platform-core": "dev-feature/pla-1081/authorizable-type-fields",
         "phrity/websocket": "^1.0",
         "rebing/graphql-laravel": "^9.0.0-rc1",
         "spatie/laravel-package-tools": "^1.0",
@@ -52,6 +52,7 @@
             "@php ./vendor/bin/testbench package:discover --ansi"
         ]
     },
+    "repositories": [],
     "config": {
         "optimize-autoloader": true,
         "sort-packages": true,

--- a/src/GraphQL/Types/BeamClaimType.php
+++ b/src/GraphQL/Types/BeamClaimType.php
@@ -76,7 +76,7 @@ class BeamClaimType extends Type
                 'type' => GraphQL::type('String!'),
                 'description' => __('enjin-platform-beam::type.beam_claim.field.code'),
                 'resolve' => fn ($claim) => $claim->code ? $claim->singleUseCode : '',
-                'excludeFrom' => ['GetBeams'],
+                'excludeFrom' => ['GetBeam', 'GetBeams'],
             ],
             'identifierCode' => [
                 'type' => GraphQL::type('String!'),
@@ -94,7 +94,7 @@ class BeamClaimType extends Type
                 },
                 'selectable' => false,
                 'is_relation' => false,
-                'excludeFrom' => ['GetBeams'],
+                'excludeFrom' => ['GetBeam', 'GetBeams'],
             ],
         ];
     }

--- a/src/GraphQL/Types/BeamClaimType.php
+++ b/src/GraphQL/Types/BeamClaimType.php
@@ -3,12 +3,14 @@
 namespace Enjin\Platform\Beam\GraphQL\Types;
 
 use Enjin\Platform\Beam\Models\BeamClaim;
+use Enjin\Platform\GraphQL\Schemas\Traits\HasAuthorizableFields;
 use Enjin\Platform\Traits\HasSelectFields;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class BeamClaimType extends Type
 {
     use HasSelectFields;
+    use HasAuthorizableFields;
 
     /**
      * Get the type's attributes.
@@ -74,6 +76,7 @@ class BeamClaimType extends Type
                 'type' => GraphQL::type('String!'),
                 'description' => __('enjin-platform-beam::type.beam_claim.field.code'),
                 'resolve' => fn ($claim) => $claim->code ? $claim->singleUseCode : '',
+                'excludeFrom' => ['GetBeams'],
             ],
             'identifierCode' => [
                 'type' => GraphQL::type('String!'),
@@ -91,6 +94,7 @@ class BeamClaimType extends Type
                 },
                 'selectable' => false,
                 'is_relation' => false,
+                'excludeFrom' => ['GetBeams'],
             ],
         ];
     }

--- a/src/GraphQL/Types/BeamType.php
+++ b/src/GraphQL/Types/BeamType.php
@@ -7,7 +7,6 @@ use Enjin\Platform\Beam\Enums\BeamFlag;
 use Enjin\Platform\Beam\GraphQL\Traits\HasBeamCommonFields;
 use Enjin\Platform\Beam\Models\Beam;
 use Enjin\Platform\Beam\Services\BeamService;
-use Enjin\Platform\Beam\Support\ClaimProbabilities;
 use Enjin\Platform\GraphQL\Types\Pagination\ConnectionInput;
 use Enjin\Platform\Traits\HasSelectFields;
 use Illuminate\Pagination\Cursor;
@@ -94,7 +93,7 @@ class BeamType extends Type
             'probabilities' => [
                 'type' => GraphQL::type('Object'),
                 'description' => __('enjin-platform-beam::type.beam.field.probabilities'),
-                'resolve' => fn ($beam) => ClaimProbabilities::getProbabilities($beam->code)['probabilities'] ?? null,
+                'selectable' => false,
                 'is_relation' => false,
             ],
             'claims' => [

--- a/src/Models/Laravel/Beam.php
+++ b/src/Models/Laravel/Beam.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Enjin\Platform\Beam\Database\Factories\BeamFactory;
 use Enjin\Platform\Beam\Enums\BeamFlag;
 use Enjin\Platform\Beam\Services\BeamService;
+use Enjin\Platform\Beam\Support\ClaimProbabilities;
 use Enjin\Platform\Models\BaseModel;
 use Enjin\Platform\Models\Laravel\Collection;
 use Enjin\Platform\Support\BitMask;
@@ -139,6 +140,16 @@ class Beam extends BaseModel
     {
         return Attribute::make(
             get: fn () => Cache::get(BeamService::key($this->code), BeamService::claimsCountResolver($this->code))
+        );
+    }
+
+    /**
+     * Interact with the beam's claims remaining attribute.
+     */
+    protected function probabilities(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => ClaimProbabilities::getProbabilities($this->code)['probabilities'] ?? null
         );
     }
 

--- a/src/Models/Laravel/Traits/EagerLoadSelectFields.php
+++ b/src/Models/Laravel/Traits/EagerLoadSelectFields.php
@@ -69,7 +69,7 @@ trait EagerLoadSelectFields
         $fields = Arr::get($selections, $attribute, $selections);
         $select = array_filter([
             'id',
-            isset($fields['qr']) ? 'code' : null,
+            Arr::hasAny($fields, ['qr', 'probabilities', 'isClaimable']) ? 'code' : null,
             isset($fields['collection']) ? 'collection_chain_id' : null,
             ...(isset($fields['isClaimable']) ? ['start', 'end', 'flags_mask'] : []),
             ...BeamType::getSelectFields($fieldKeys = array_keys($fields)),

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -8,7 +8,7 @@ env:
   - CACHE_DRIVER="redis"
   - QUEUE_CONNECTION="redis"
   - CHAIN="substrate"
-  - NETWORK="polkadot"
+  - NETWORK="enjin"
   - DAEMON_ACCOUNT="0x68b427dda4f3894613e113b570d5878f3eee981196133e308c0a82584cf2e160"
 
 providers:

--- a/tests/Feature/GraphQL/Queries/GetBeamTest.php
+++ b/tests/Feature/GraphQL/Queries/GetBeamTest.php
@@ -6,6 +6,7 @@ use Enjin\Platform\Beam\Models\BeamScan;
 use Enjin\Platform\Beam\Tests\Feature\GraphQL\TestCaseGraphQL;
 use Enjin\Platform\Beam\Tests\Feature\Traits\SeedBeamData;
 use Enjin\Platform\Providers\Faker\SubstrateProvider;
+use Illuminate\Support\Str;
 
 class GetBeamTest extends TestCaseGraphQL
 {
@@ -156,5 +157,20 @@ class GetBeamTest extends TestCaseGraphQL
         $response = $this->graphql($this->method, ['code' => fake()->text(2000)], true);
 
         $this->assertArraySubset(['code' => ['The code field must not be greater than 1024 characters.']], $response['error']);
+    }
+
+    public function test_it_hides_code_field_when_unauthenticated()
+    {
+        config([
+            'enjin-platform.auth' => 'basic_token',
+            'enjin-platform.auth_drivers.basic_token.token' => Str::random(),
+        ]);
+
+        $response = $this->graphql($this->method, ['code' => $this->beam->code], true);
+        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', $response['error']);
+
+        config([
+            'enjin-platform.auth' => null,
+        ]);
     }
 }

--- a/tests/Feature/GraphQL/Queries/GetBeamsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetBeamsTest.php
@@ -96,7 +96,7 @@ class GetBeamsTest extends TestCaseGraphQL
         ]);
 
         $response = $this->graphql($this->method, [], true);
-        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', $response['errors'][0]['message']);
+        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', json_encode($response));
 
         config([
             'enjin-platform.auth' => null,

--- a/tests/Feature/GraphQL/Queries/GetBeamsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetBeamsTest.php
@@ -96,7 +96,7 @@ class GetBeamsTest extends TestCaseGraphQL
         ]);
 
         $response = $this->graphql($this->method, [], true);
-        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', $response['error']);
+        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', $response['errors'][0]['message']);
 
         config([
             'enjin-platform.auth' => null,

--- a/tests/Feature/GraphQL/Queries/GetBeamsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetBeamsTest.php
@@ -87,4 +87,19 @@ class GetBeamsTest extends TestCaseGraphQL
             'names.0' => ['The names.0 field must not be greater than 255 characters.'],
         ], $response['error']);
     }
+
+    public function test_it_hides_code_field_when_unauthenticated()
+    {
+        config([
+            'enjin-platform.auth' => 'basic_token',
+            'enjin-platform.auth_drivers.basic_token.token' => Str::random(),
+        ]);
+
+        $response = $this->graphql($this->method, [], true);
+        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', $response['error']);
+
+        config([
+            'enjin-platform.auth' => null,
+        ]);
+    }
 }

--- a/tests/Feature/GraphQL/Queries/GetBeamsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetBeamsTest.php
@@ -96,7 +96,7 @@ class GetBeamsTest extends TestCaseGraphQL
         ]);
 
         $response = $this->graphql($this->method, [], true);
-        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', json_encode($response));
+        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', $response['error']);
 
         config([
             'enjin-platform.auth' => null,

--- a/tests/Feature/GraphQL/Resources/GetBeam.graphql
+++ b/tests/Feature/GraphQL/Resources/GetBeam.graphql
@@ -24,6 +24,13 @@ query GetBeam($code: String!, $account: String) {
       frozen
       network
     }
+    claims {
+        edges {
+            node {
+                code
+            }
+        }
+    }
     claimsRemaining
   }
 }

--- a/tests/Feature/GraphQL/TestCaseGraphQL.php
+++ b/tests/Feature/GraphQL/TestCaseGraphQL.php
@@ -83,6 +83,10 @@ class TestCaseGraphQL extends BaseTestCase
             $data['error'] = $data['errors'][0]['message'];
         }
 
+        if ($expectError && !isset($data['error'])) {
+            throw new ExpectationFailedException('Test expected to yield an error, however returned successfully with the following: ' . json_encode($data));
+        }
+
         return $expectError ? $data : Arr::get($data['data'], $query);
     }
 


### PR DESCRIPTION
Bugfixes and updates for non-selectable fields and blockchain update.

Requires: https://github.com/enjin/platform-core/pull/65