### PR TITLE
Add Attributes Field to BeamClaimType

### DIFF
--- a/lang/en/type.php
+++ b/lang/en/type.php
@@ -28,5 +28,5 @@ return [
     'beam_scan.field.message' => 'The message to sign.',
     'beam_scan.field.walletPublicKey' => 'The wallet public key.',
     'integer_range.description' => "A string value that can be used to represent a range of integer numbers.  Use a double full stop to supply a range between 2 integers. \n\nExample \[\"1\",\"2\",\"3..8\"\]",
-    'attribute.description' => 'The initial attribute for the token.',
+    'attribute.description' => 'An initial attribute to set for the token when minting on demand.',
 ];

--- a/lang/en/type.php
+++ b/lang/en/type.php
@@ -28,4 +28,5 @@ return [
     'beam_scan.field.message' => 'The message to sign.',
     'beam_scan.field.walletPublicKey' => 'The wallet public key.',
     'integer_range.description' => "A string value that can be used to represent a range of integer numbers.  Use a double full stop to supply a range between 2 integers. \n\nExample \[\"1\",\"2\",\"3..8\"\]",
+    'attribute.description' => 'The initial attribute for the token.',
 ];

--- a/src/GraphQL/Types/AttributeType.php
+++ b/src/GraphQL/Types/AttributeType.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Enjin\Platform\Beam\GraphQL\Types;
+
+use Rebing\GraphQL\Support\Facades\GraphQL;
+
+class AttributeType extends Type
+{
+    /**
+     * Get the type's attributes.
+     */
+    public function attributes(): array
+    {
+        return [
+            'name' => 'AttributeType',
+            'description' => __('enjin-platform-beam::type.attribute.description'),
+        ];
+    }
+
+    /**
+     * Get the type's fields definition.
+     */
+    public function fields(): array
+    {
+        return [
+            'key' => [
+                'type' => GraphQL::type('String'),
+                'description' => __('enjin-platform::mutation.batch_set_attribute.args.key'),
+            ],
+            'value' => [
+                'type' => GraphQL::type('String'),
+                'description' => __('enjin-platform::mutation.batch_set_attribute.args.value'),
+            ],
+        ];
+    }
+}

--- a/src/GraphQL/Types/BeamClaimType.php
+++ b/src/GraphQL/Types/BeamClaimType.php
@@ -96,6 +96,10 @@ class BeamClaimType extends Type
                 'is_relation' => false,
                 'excludeFrom' => ['GetBeam', 'GetBeams'],
             ],
+            'attributes' => [
+                'type' => GraphQL::type('[AttributeType]'),
+                'description' => __('enjin-platform-beam::type.attribute.description'),
+            ],
         ];
     }
 }

--- a/tests/Feature/GraphQL/Resources/GetClaims.graphql
+++ b/tests/Feature/GraphQL/Resources/GetClaims.graphql
@@ -22,6 +22,10 @@ query GetClaims(
         claimStatus
         quantity
         identifierCode
+        attributes {
+          key
+          value
+        }
         wallet {
           account {
             publicKey


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces an 'attributes' field to the BeamClaimType. The main changes include:
- Addition of a new 'AttributeType' class in the GraphQL types.
- Addition of 'attributes' field in the 'BeamClaimType' class.
- Update of the 'GetClaims' GraphQL query in the tests to include the 'attributes' field.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `lang/en/type.php`: Added a new 'attribute.description' field in the language file for English.
- `src/GraphQL/Types/AttributeType.php`: Introduced a new 'AttributeType' class with 'key' and 'value' fields.
- `src/GraphQL/Types/BeamClaimType.php`: Added an 'attributes' field of type 'AttributeType' to the 'BeamClaimType' class.
- `tests/Feature/GraphQL/Resources/GetClaims.graphql`: Updated the 'GetClaims' GraphQL query in the tests to include the 'attributes' field.
</details>
