### PR TITLE
[PLA-136] Add idempotencyKey to ClaimBeam Mutation

### DIFF
--- a/database/migrations/2024_02_26_013401_add_idempotency_key_to_beam_claims_table.php
+++ b/database/migrations/2024_02_26_013401_add_idempotency_key_to_beam_claims_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('beam_claims', function (Blueprint $table) {
+            $table->string('idempotency_key', 255)->nullable()->unique();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('beam_claims', function (Blueprint $table) {
+            $table->dropColumn('idempotency_key');
+        });
+    }
+};

--- a/src/BeamServiceProvider.php
+++ b/src/BeamServiceProvider.php
@@ -37,6 +37,7 @@ class BeamServiceProvider extends PackageServiceProvider
             ->hasMigration('create_beam_scans_table')
             ->hasMigration('update_beams_table')
             ->hasMigration('add_collection_chain_id_to_beam_batches_table')
+            ->hasMigration('add_idempotency_key_to_beam_claims_table')
             ->hasRoute('enjin-platform-beam')
             ->hasTranslations();
     }

--- a/src/GraphQL/Types/BeamClaimType.php
+++ b/src/GraphQL/Types/BeamClaimType.php
@@ -105,6 +105,11 @@ class BeamClaimType extends Type
                 'description' => __('enjin-platform::type.transaction.description'),
                 'is_relation' => true,
             ],
+            'idempotencyKey' => [
+                'type' => GraphQL::type('String'),
+                'description' => __('enjin-platform::type.transaction.field.idempotencyKey'),
+                'alias' => 'idempotency_key',
+            ],
         ];
     }
 }

--- a/src/Jobs/ClaimBeam.php
+++ b/src/Jobs/ClaimBeam.php
@@ -126,7 +126,13 @@ class ClaimBeam implements ShouldQueue
     protected function buildRequiredClaimAttributes(BatchService $batchService, Model $claim): array
     {
         return [
-            ...Arr::only($this->data, ['wallet_public_key', 'claimed_at', 'state', 'ip_address']),
+            ...Arr::only($this->data, [
+                'wallet_public_key',
+                'claimed_at',
+                'state',
+                'ip_address',
+                'idempotency_key',
+            ]),
             'beam_batch_id' => $batchService->getNextBatchId(
                 BeamType::getEnumCase($claim->type),
                 $claim->beam->collection_chain_id

--- a/src/Models/Laravel/BeamClaim.php
+++ b/src/Models/Laravel/BeamClaim.php
@@ -61,6 +61,7 @@ class BeamClaim extends BaseModel
         'ip_address',
         'code',
         'nonce',
+        'idempotency_key',
     ];
 
     /**

--- a/tests/Feature/GraphQL/Resources/GetClaims.graphql
+++ b/tests/Feature/GraphQL/Resources/GetClaims.graphql
@@ -22,6 +22,7 @@ query GetClaims(
         claimStatus
         quantity
         identifierCode
+        idempotencyKey
         attributes {
           key
           value

--- a/tests/Feature/GraphQL/Resources/GetPendingClaims.graphql
+++ b/tests/Feature/GraphQL/Resources/GetPendingClaims.graphql
@@ -18,6 +18,7 @@ query GetPendingClaims(
         claimStatus
         quantity
         identifierCode
+        idempotencyKey
         attributes {
           key
           value


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Adds support for idempotency key in beam claims to prevent duplicate claims.
- Introduces a new column `idempotency_key` in the `beam_claims` table.
- Updates `ClaimBeamMutation` to handle idempotency key, including checks for existing claims with the same key.
- Adds `idempotencyKey` field to `BeamClaimType` and includes it in relevant GraphQL queries.
- Modifies `BeamService` and related jobs to support idempotency key during beam claim processing.
- Includes tests to verify the functionality of claiming beams with an idempotency key.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>2024_02_26_013401_add_idempotency_key_to_beam_claims_table.php</strong><dd><code>Add Idempotency Key Column to Beam Claims Table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

database/migrations/2024_02_26_013401_add_idempotency_key_to_beam_claims_table.php
<li>Adds a new migration to include <code>idempotency_key</code> column in <code>beam_claims</code> <br>table.<br> <li> Ensures <code>idempotency_key</code> is nullable and unique.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/66/files#diff-d0ad11696bd1ee5d9871159a9951d807643e40b07a8b0ce8b7649ced27d28a1a">+27/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ClaimBeamMutation.php</strong><dd><code>Integrate Idempotency Key in ClaimBeamMutation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Mutations/ClaimBeamMutation.php
<li>Integrates idempotency key handling in the <code>ClaimBeamMutation</code>.<br> <li> Adds idempotency key to the mutation arguments and checks for existing <br>claims with the same key.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/66/files#diff-f4080d41dd3f655ad87332d52f8518891a8259c17242a35f41dd2fd3c8756bbe">+12/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BeamClaimType.php</strong><dd><code>Add Idempotency Key Field to BeamClaimType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Types/BeamClaimType.php
- Adds `idempotencyKey` field to the `BeamClaimType`.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/66/files#diff-7ecf5e220b5e25127da703c9bf15310b32abe2e271f0c21e932b9a516282abcb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ClaimBeam.php</strong><dd><code>Include Idempotency Key in Beam Claim Attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Jobs/ClaimBeam.php
<li>Includes <code>idempotency_key</code> in the attributes built for a beam claim.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/66/files#diff-7d3aba416652164d8d70a96632010b3833033de1cd8b8bc965a72e135c8cc264">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BeamClaim.php</strong><dd><code>Add Idempotency Key to BeamClaim Model Fillable Attributes</code></dd></summary>
<hr>

src/Models/Laravel/BeamClaim.php
<li>Adds <code>idempotency_key</code> to the fillable attributes of <code>BeamClaim</code> model.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/66/files#diff-75c5b55a6305f1855fcf124dd6df0316a1cb311a1fbb1f3ca89370af6e41db42">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BeamService.php</strong><dd><code>Support Idempotency Key in BeamService Claim Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/BeamService.php
<li>Modifies <code>claim</code> method to accept an optional <code>idempotencyKey</code>.<br> <li> Adjusts <code>buildClaimBeamData</code> to include <code>idempotencyKey</code> in the claim <br>data.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/66/files#diff-ad61fe9557d8825aa83df9c1b4f43f366501cc39578bb179cc229a0defca6578">+16/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GetClaims.graphql</strong><dd><code>Add Idempotency Key to GetClaims Query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Resources/GetClaims.graphql
- Adds `idempotencyKey` to the `GetClaims` GraphQL query.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/66/files#diff-6dc6f9b7e023d43b4cc421c8bf95385455628048a3cca8ae5cd74d1fe649ff6b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GetPendingClaims.graphql</strong><dd><code>Add Idempotency Key to GetPendingClaims Query</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Resources/GetPendingClaims.graphql
- Adds `idempotencyKey` to the `GetPendingClaims` GraphQL query.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/66/files#diff-37d30c23421977d6d6791de633f9714a260f69fa54cd6c9f634d0484368d915f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>BeamServiceProvider.php</strong><dd><code>Register New Migration for Idempotency Key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/BeamServiceProvider.php
<li>Registers the new migration <code>add_idempotency_key_to_beam_claims_table</code> <br>with the service provider.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/66/files#diff-f80ec4f5b8eb2dc8bb7dc8a8f97ef0d7f175b93fe432c748e3d4861424395d2e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ClaimBeamTest.php</strong><dd><code>Test Beam Claim with Idempotency Key</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/ClaimBeamTest.php
- Adds a test to verify beam claim with idempotency key.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/66/files#diff-abca64f724b7b0de167a1249ce0190d78276834a2881f92efb066d6b1ae59d19">+23/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

