### PR TITLE
[PLA-1708] Remove validation on GetBeam

### DIFF
--- a/src/GraphQL/Mutations/ClaimBeamMutation.php
+++ b/src/GraphQL/Mutations/ClaimBeamMutation.php
@@ -113,7 +113,7 @@ class ClaimBeamMutation extends Mutation implements PlatformPublicGraphQlOperati
                 'filled',
                 'max:1024',
                 new NotExpired($beamCode),
-                $singleUse ? new SingleUseCodeExist() : '',
+                $singleUse ? new SingleUseCodeExist(true) : '',
                 new CanClaim($singleUse),
                 new NotPaused($beamCode),
                 ...$this->getClaimConditionRules($singleUse),

--- a/src/GraphQL/Queries/GetBeamQuery.php
+++ b/src/GraphQL/Queries/GetBeamQuery.php
@@ -5,7 +5,6 @@ namespace Enjin\Platform\Beam\GraphQL\Queries;
 use Closure;
 use Enjin\Platform\Beam\GraphQL\Traits\HasBeamCommonFields;
 use Enjin\Platform\Beam\Models\Beam;
-use Enjin\Platform\Beam\Rules\CanClaim;
 use Enjin\Platform\Beam\Rules\ScanLimit;
 use Enjin\Platform\Beam\Rules\SingleUseCodeExist;
 use Enjin\Platform\Beam\Services\BeamService;
@@ -85,7 +84,7 @@ class GetBeamQuery extends Query implements PlatformPublicGraphQlOperation
                 'bail',
                 'filled',
                 'max:1024',
-                $singleUse ? new SingleUseCodeExist() : 'exists:beams,code,deleted_at,NULL'
+                $singleUse ? new SingleUseCodeExist() : 'exists:beams,code,deleted_at,NULL',
             ],
             'account' => ['sometimes', 'bail', new ValidSubstrateAccount(), new ScanLimit()],
         ];

--- a/src/GraphQL/Queries/GetBeamQuery.php
+++ b/src/GraphQL/Queries/GetBeamQuery.php
@@ -85,8 +85,7 @@ class GetBeamQuery extends Query implements PlatformPublicGraphQlOperation
                 'bail',
                 'filled',
                 'max:1024',
-                $singleUse ? new SingleUseCodeExist() : 'exists:beams,code,deleted_at,NULL',
-                new CanClaim($singleUse),
+                $singleUse ? new SingleUseCodeExist() : 'exists:beams,code,deleted_at,NULL'
             ],
             'account' => ['sometimes', 'bail', new ValidSubstrateAccount(), new ScanLimit()],
         ];

--- a/src/Rules/SingleUseCodeExist.php
+++ b/src/Rules/SingleUseCodeExist.php
@@ -9,6 +9,10 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 class SingleUseCodeExist implements ValidationRule
 {
+    public function __construct(protected bool $isClaiming = false)
+    {
+    }
+
     /**
      * Determine if the validation rule passes.
      *
@@ -20,7 +24,11 @@ class SingleUseCodeExist implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (BeamService::isSingleUse($value) && BeamClaim::withSingleUseCode($value)->claimable()->exists()) {
+        if (BeamService::isSingleUse($value) &&
+                BeamClaim::withSingleUseCode($value)
+                    ->when($this->isClaiming, fn ($query) => $query->claimable())
+                    ->exists()
+        ) {
             return;
         }
 

--- a/tests/Feature/GraphQL/Queries/GetBeamTest.php
+++ b/tests/Feature/GraphQL/Queries/GetBeamTest.php
@@ -112,21 +112,6 @@ class GetBeamTest extends TestCaseGraphQL
     }
 
     /**
-     * Test get beam with no more claims.
-     */
-    public function test_it_will_fail_with_no_more_claims(): void
-    {
-        $this->claimAllBeams(resolve(SubstrateProvider::class)->public_key());
-
-        $response = $this->graphql($this->method, [
-            'code' => $this->beam->code,
-            'account' => resolve(SubstrateProvider::class)->public_key(),
-        ], true);
-
-        $this->assertArraySubset(['code' => ['There are no more claims available.']], $response['error']);
-    }
-
-    /**
      * Test isclaimable flag with no more claims.
      */
     public function test_isclaimable_flag_with_no_more_claims(): void


### PR DESCRIPTION
## **Type**
enhancement, tests


___

## **Description**
- Enhanced the `SingleUseCodeExist` rule to support conditional claimability checks, improving the flexibility of beam claim validations.
- Added new tests to verify the functionality of retrieving beams with single-use codes, ensuring robustness.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClaimBeamMutation.php</strong><dd><code>Enhance Single Use Code Validation for Claiming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Mutations/ClaimBeamMutation.php
<li>Added a boolean parameter to <code>SingleUseCodeExist</code> constructor to support <br>conditional claimability checks.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/69/files#diff-f4080d41dd3f655ad87332d52f8518891a8259c17242a35f41dd2fd3c8756bbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SingleUseCodeExist.php</strong><dd><code>Conditional Claimability Check in Single Use Code Validation</code></dd></summary>
<hr>

src/Rules/SingleUseCodeExist.php
<li>Introduced a constructor with a <code>bool</code> parameter to toggle claimability <br>checks.<br> <li> Modified the <code>validate</code> method to conditionally check for claimability <br>based on the new constructor parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/69/files#diff-4f1987ff619e782801c599f1271c61f834783fd6d425232bfab44e0ac2f14a56">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GetBeamTest.php</strong><dd><code>Add Tests for Single Use Code Beam Retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Queries/GetBeamTest.php
<li>Added tests for getting beams with single-use codes.<br> <li> Utilized <code>BeamType</code> and <code>BeamService</code> for setting up test conditions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/69/files#diff-68c2161034999b5254e8583b7bfae4c3bf8e8e7b9f4cf0722ef33522e28a4a91">+27/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

