### PR TITLE
[PLA-1778] Add singleUseCodes filter to GetClaims query.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     "scripts": {
         "build-sr25519": "cd vendor/gmajor/sr25519-bindings/go && go build -buildmode=c-shared -o sr25519.so . && mv sr25519.so ../src/Crypto/sr25519.so",
         "analyse": "vendor/bin/phpstan analyse",
+        "fix": "vendor/bin/php-cs-fixer fix",
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html ../../temp/coverage",
         "post-autoload-dump": [

--- a/lang/en/mutation.php
+++ b/lang/en/mutation.php
@@ -3,6 +3,7 @@
 return [
     'claim_beam.args.account' => 'The wallet account.',
     'claim_beam.args.code' => 'The beam code.',
+    'claim_beam.args.single_use_code' => 'The beam single use code.',
     'claim_beam.args.cryptoSignatureType' => 'The signature crypto type. This field is optional and it will use sr25519 by default.',
     'claim_beam.args.signature' => 'The signed message.',
     'claim_beam.description' => 'Mutation for claiming a beam.',

--- a/src/GraphQL/Queries/GetClaimsQuery.php
+++ b/src/GraphQL/Queries/GetClaimsQuery.php
@@ -56,6 +56,11 @@ class GetClaimsQuery extends Query
                 'description' => __('enjin-platform-beam::mutation.claim_beam.args.code'),
                 'rules' => ['prohibits:ids'],
             ],
+            'singleUseCodes' => [
+                'type' => GraphQL::type('[String]'),
+                'description' => __('enjin-platform-beam::mutation.claim_beam.args.single_use_code'),
+                'rules' => ['prohibits:ids'],
+            ],
             'accounts' => [
                 'type' => GraphQL::type('[String]'),
                 'description' => __('enjin-platform-beam::mutation.claim_beam.args.account'),
@@ -80,6 +85,7 @@ class GetClaimsQuery extends Query
         return BeamClaim::loadSelectFields($resolveInfo, $this->name)
             ->when(Arr::get($args, 'ids'), fn ($query) => $query->whereIn('id', $args['ids']))
             ->when(Arr::get($args, 'codes'), fn ($query) => $query->hasCode($args['codes']))
+            ->when(Arr::get($args, 'singleUseCodes'), fn ($query) => $query->hasSingleUseCode($args['singleUseCodes']))
             ->when(Arr::get($args, 'accounts'), fn ($query) => $query->whereIn(
                 'wallet_public_key',
                 collect($args['accounts'])->map(fn ($account) => SS58Address::getPublicKey($account))

--- a/src/GraphQL/Queries/GetClaimsQuery.php
+++ b/src/GraphQL/Queries/GetClaimsQuery.php
@@ -54,12 +54,12 @@ class GetClaimsQuery extends Query
             'codes' => [
                 'type' => GraphQL::type('[String]'),
                 'description' => __('enjin-platform-beam::mutation.claim_beam.args.code'),
-                'rules' => ['prohibits:ids'],
+                'rules' => ['prohibits:ids', 'array', 'max:100'],
             ],
             'singleUseCodes' => [
                 'type' => GraphQL::type('[String]'),
                 'description' => __('enjin-platform-beam::mutation.claim_beam.args.single_use_code'),
-                'rules' => ['prohibits:ids'],
+                'rules' => ['prohibits:ids', 'array', 'max:100'],
             ],
             'accounts' => [
                 'type' => GraphQL::type('[String]'),
@@ -101,7 +101,8 @@ class GetClaimsQuery extends Query
     {
         return [
             'ids.*' => [new MinBigInt(1), new MaxBigInt()],
-            'codes.*' => ['max:1024'],
+            'codes.*' => ['max:32'],
+            'singleUseCodes.*' => ['max:512'],
             'accounts.*' => [new ValidSubstrateAccount()],
         ];
     }

--- a/src/Models/Laravel/BeamClaim.php
+++ b/src/Models/Laravel/BeamClaim.php
@@ -5,6 +5,7 @@ namespace Enjin\Platform\Beam\Models\Laravel;
 use Enjin\Platform\Beam\Database\Factories\BeamClaimFactory;
 use Enjin\Platform\Beam\Enums\BeamFlag;
 use Enjin\Platform\Beam\Enums\BeamRoute;
+use Enjin\Platform\Beam\Models\Laravel\Traits\HasSingleUseCodeScope;
 use Enjin\Platform\Beam\Services\BeamService;
 use Enjin\Platform\Models\BaseModel;
 use Enjin\Platform\Models\Laravel\Collection;
@@ -25,15 +26,15 @@ use Staudenmeir\EloquentEagerLimit\HasEagerLimit;
 
 class BeamClaim extends BaseModel
 {
-    use HasFactory;
-    use SoftDeletes;
-    use Traits\HasBeamQr;
-    use Traits\HasCodeScope;
-    use MassPrunable;
-    use Traits\HasClaimable;
-    use Traits\EagerLoadSelectFields;
     use HasEagerLimit;
-
+    use HasFactory;
+    use HasSingleUseCodeScope;
+    use MassPrunable;
+    use SoftDeletes;
+    use Traits\EagerLoadSelectFields;
+    use Traits\HasBeamQr;
+    use Traits\HasClaimable;
+    use Traits\HasCodeScope;
 
     /**
      * The attributes that aren't mass assignable.

--- a/src/Models/Laravel/Traits/HasSingleUseCodeScope.php
+++ b/src/Models/Laravel/Traits/HasSingleUseCodeScope.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Enjin\Platform\Beam\Models\Laravel\Traits;
+
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+
+trait HasSingleUseCodeScope
+{
+    /**
+     * Local scope for beam code.
+     */
+    public function scopeHasSingleUseCode(Builder $query, string|array|null $code): Builder
+    {
+        try {
+            if (is_array($code)) {
+                $singleUseCode = array_map(function ($item) {
+                    return explode(':', decrypt($item))[0];
+                }, $code);
+            } else {
+                $singleUseCode = explode(':', decrypt($code))[0];
+            }
+
+            return $query->whereIn('code', Arr::wrap($singleUseCode));
+        } catch (\Throwable $exception) {
+            return $query;
+        }
+    }
+}

--- a/tests/Feature/GraphQL/Queries/GetClaimsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetClaimsTest.php
@@ -56,7 +56,16 @@ class GetClaimsTest extends TestCaseGraphQL
      */
     public function test_it_can_get_claims_with_single_use_codes(): void
     {
-        $response = $this->graphql($this->method, ['codes' => [$this->beam->claims[0]->singleUseCode]]);
+        $response = $this->graphql($this->method, ['singleUseCodes' => [$this->beam->claims[0]->singleUseCode]]);
+        $this->assertNotEmpty($response['totalCount']);
+    }
+
+    /**
+     * Test get beam with codes.
+     */
+    public function test_it_can_get_claims_with_multiple_single_use_codes(): void
+    {
+        $response = $this->graphql($this->method, ['singleUseCodes' => [$this->beam->claims[0]->singleUseCode, $this->beam->claims[1]->singleUseCode]]);
         $this->assertNotEmpty($response['totalCount']);
     }
 

--- a/tests/Feature/GraphQL/Queries/GetClaimsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetClaimsTest.php
@@ -52,6 +52,15 @@ class GetClaimsTest extends TestCaseGraphQL
     }
 
     /**
+     * Test get beam with codes.
+     */
+    public function test_it_can_get_claims_with_single_use_codes(): void
+    {
+        $response = $this->graphql($this->method, ['codes' => [$this->beam->claims[0]->singleUseCode]]);
+        $this->assertNotEmpty($response['totalCount']);
+    }
+
+    /**
      * Test get beam with accounts.
      */
     public function test_it_can_get_claims_with_accounts(): void

--- a/tests/Feature/GraphQL/Resources/GetClaims.graphql
+++ b/tests/Feature/GraphQL/Resources/GetClaims.graphql
@@ -1,6 +1,7 @@
 query GetClaims(
   $ids: [BigInt]
   $codes: [String]
+  $singleUseCodes: [String]
   $accounts: [String]
   $states: [ClaimStatus]
   $after: String
@@ -9,6 +10,7 @@ query GetClaims(
   GetClaims(
     ids: $ids
     codes: $codes
+    singleUseCodes: $singleUseCodes
     accounts: $accounts
     states: $states
     after: $after


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `singleUseCodes` argument to `GetClaims` query and implemented filtering logic.
- Created `HasSingleUseCodeScope` trait for filtering by single use code and integrated it into the `BeamClaim` model.
- Added translation for `single_use_code` argument in `claim_beam`.
- Added test for `singleUseCodes` filter in `GetClaims` query.
- Added `fix` script for PHP CS Fixer in `composer.json`.
- Added `singleUseCodes` argument to `GetClaims` GraphQL query.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mutation.php</strong><dd><code>Add translation for single use code argument.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lang/en/mutation.php
- Added translation for `single_use_code` argument in `claim_beam`.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/71/files#diff-4f781bb4f33dedd74b3c9d8f53e97e9bfcb9dff0dd4883bc2d3338fbec35ffe3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GetClaimsQuery.php</strong><dd><code>Add singleUseCodes filter to GetClaims query.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Queries/GetClaimsQuery.php
<li>Added <code>singleUseCodes</code> argument to <code>GetClaims</code> query.<br> <li> Implemented filtering logic for <code>singleUseCodes</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/71/files#diff-c13e16e827dd73faba2e6168c5ceb215f82386841f78e7a1ced3b4eb22e61f10">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BeamClaim.php</strong><dd><code>Integrate HasSingleUseCodeScope trait in BeamClaim model.</code></dd></summary>
<hr>

src/Models/Laravel/BeamClaim.php
- Added `HasSingleUseCodeScope` trait to `BeamClaim` model.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/71/files#diff-75c5b55a6305f1855fcf124dd6df0316a1cb311a1fbb1f3ca89370af6e41db42">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HasSingleUseCodeScope.php</strong><dd><code>Create HasSingleUseCodeScope trait for single use code filtering.</code></dd></summary>
<hr>

src/Models/Laravel/Traits/HasSingleUseCodeScope.php
<li>Created <code>HasSingleUseCodeScope</code> trait for filtering by single use code.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/71/files#diff-532d22067e1cfa1082b912a760eab4f56edd4173444bee5c38434f9b7caebc4e">+29/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>composer.json</strong><dd><code>Add fix script for PHP CS Fixer.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composer.json
- Added `fix` script for PHP CS Fixer.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/71/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GetClaims.graphql</strong><dd><code>Add singleUseCodes argument to GetClaims GraphQL query.</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Resources/GetClaims.graphql
- Added `singleUseCodes` argument to `GetClaims` GraphQL query.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/71/files#diff-6dc6f9b7e023d43b4cc421c8bf95385455628048a3cca8ae5cd74d1fe649ff6b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GetClaimsTest.php</strong><dd><code>Add test for singleUseCodes filter in GetClaims query.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Queries/GetClaimsTest.php
- Added test for `singleUseCodes` filter in `GetClaims` query.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/71/files#diff-1b0cf59045471563e6309458630fc1bc758913f608678e89b6d495fbbbf65c0c">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

