### PR TITLE
[PLA-1780] Ensure Beams can't be claimed from base code when set to Single Use

### DIFF
--- a/src/Rules/CanClaim.php
+++ b/src/Rules/CanClaim.php
@@ -38,12 +38,10 @@ class CanClaim implements DataAwareRule, ValidationRule
 
         if ($this->singleUse) {
             $value = explode(':', decrypt($value), 3)[1];
-        } else {
-            if (BeamService::hasSingleUse($value)) {
-                $fail('enjin-platform-beam::validation.can_claim')->translate();
+        } elseif (BeamService::hasSingleUse($value)) {
+            $fail('enjin-platform-beam::validation.can_claim')->translate();
 
-                return;
-            }
+            return;
         }
 
         $passes = ((int) Cache::get(BeamService::key($value), BeamService::claimsCountResolver($value))) > 0;

--- a/src/Rules/CanClaim.php
+++ b/src/Rules/CanClaim.php
@@ -38,6 +38,12 @@ class CanClaim implements DataAwareRule, ValidationRule
 
         if ($this->singleUse) {
             $value = explode(':', decrypt($value), 3)[1];
+        } else {
+            if (BeamService::hasSingleUse($value)) {
+                $fail('enjin-platform-beam::validation.can_claim')->translate();
+
+                return;
+            }
         }
 
         $passes = ((int) Cache::get(BeamService::key($value), BeamService::claimsCountResolver($value))) > 0;


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a check in `CanClaim.php` to prevent claiming single-use beams from multi-use codes.
- Introduced a new test in `ClaimBeamTest.php` to verify that single-use beams cannot be claimed from multi-use codes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CanClaim.php</strong><dd><code>Prevent claiming single-use beams from multi-use codes.</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/Rules/CanClaim.php
<li>Added a check to prevent claiming single-use beams from multi-use <br>codes.<br> <li> Added a condition to fail validation if a single-use beam is detected <br>in a multi-use context.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/72/files#diff-2c15a74db77bf69b1b421f8c2518fe94df5a6341bea4efe221c593e5eca3bc80">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClaimBeamTest.php</strong><dd><code>Add test for single-use beam claim from multi-use code.</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/ClaimBeamTest.php
<li>Added a new test to ensure single-use beams cannot be claimed from <br>multi-use codes.<br> <li> Updated imports to include <code>BitMask</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/72/files#diff-abca64f724b7b0de167a1249ce0190d78276834a2881f92efb066d6b1ae59d19">+17/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

