### PR TITLE
V1.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     "scripts": {
         "build-sr25519": "cd vendor/gmajor/sr25519-bindings/go && go build -buildmode=c-shared -o sr25519.so . && mv sr25519.so ../src/Crypto/sr25519.so",
         "analyse": "vendor/bin/phpstan analyse",
+        "fix": "vendor/bin/php-cs-fixer fix",
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html ../../temp/coverage",
         "post-autoload-dump": [

--- a/lang/en/mutation.php
+++ b/lang/en/mutation.php
@@ -3,6 +3,7 @@
 return [
     'claim_beam.args.account' => 'The wallet account.',
     'claim_beam.args.code' => 'The beam code.',
+    'claim_beam.args.single_use_code' => 'The beam single use code.',
     'claim_beam.args.cryptoSignatureType' => 'The signature crypto type. This field is optional and it will use sr25519 by default.',
     'claim_beam.args.signature' => 'The signed message.',
     'claim_beam.description' => 'Mutation for claiming a beam.',

--- a/src/Models/Laravel/BeamClaim.php
+++ b/src/Models/Laravel/BeamClaim.php
@@ -5,6 +5,7 @@ namespace Enjin\Platform\Beam\Models\Laravel;
 use Enjin\Platform\Beam\Database\Factories\BeamClaimFactory;
 use Enjin\Platform\Beam\Enums\BeamFlag;
 use Enjin\Platform\Beam\Enums\BeamRoute;
+use Enjin\Platform\Beam\Models\Laravel\Traits\HasSingleUseCodeScope;
 use Enjin\Platform\Beam\Services\BeamService;
 use Enjin\Platform\Models\BaseModel;
 use Enjin\Platform\Models\Laravel\Collection;
@@ -25,15 +26,15 @@ use Staudenmeir\EloquentEagerLimit\HasEagerLimit;
 
 class BeamClaim extends BaseModel
 {
-    use HasFactory;
-    use SoftDeletes;
-    use Traits\HasBeamQr;
-    use Traits\HasCodeScope;
-    use MassPrunable;
-    use Traits\HasClaimable;
-    use Traits\EagerLoadSelectFields;
     use HasEagerLimit;
-
+    use HasFactory;
+    use HasSingleUseCodeScope;
+    use MassPrunable;
+    use SoftDeletes;
+    use Traits\EagerLoadSelectFields;
+    use Traits\HasBeamQr;
+    use Traits\HasClaimable;
+    use Traits\HasCodeScope;
 
     /**
      * The attributes that aren't mass assignable.

--- a/src/Models/Laravel/Traits/HasSingleUseCodeScope.php
+++ b/src/Models/Laravel/Traits/HasSingleUseCodeScope.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Enjin\Platform\Beam\Models\Laravel\Traits;
+
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+
+trait HasSingleUseCodeScope
+{
+    /**
+     * Local scope for beam code.
+     */
+    public function scopeHasSingleUseCode(Builder $query, string|array|null $code): Builder
+    {
+        try {
+            if (is_array($code)) {
+                $singleUseCode = array_map(function ($item) {
+                    return explode(':', decrypt($item))[0];
+                }, $code);
+            } else {
+                $singleUseCode = explode(':', decrypt($code))[0];
+            }
+
+            return $query->whereIn('code', Arr::wrap($singleUseCode));
+        } catch (\Throwable $exception) {
+            return $query;
+        }
+    }
+}

--- a/src/Rules/CanClaim.php
+++ b/src/Rules/CanClaim.php
@@ -38,6 +38,10 @@ class CanClaim implements DataAwareRule, ValidationRule
 
         if ($this->singleUse) {
             $value = explode(':', decrypt($value), 3)[1];
+        } elseif (BeamService::hasSingleUse($value)) {
+            $fail('enjin-platform-beam::validation.can_claim')->translate();
+
+            return;
         }
 
         $passes = ((int) Cache::get(BeamService::key($value), BeamService::claimsCountResolver($value))) > 0;

--- a/tests/Feature/GraphQL/Queries/GetClaimsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetClaimsTest.php
@@ -52,6 +52,24 @@ class GetClaimsTest extends TestCaseGraphQL
     }
 
     /**
+     * Test get beam with codes.
+     */
+    public function test_it_can_get_claims_with_single_use_codes(): void
+    {
+        $response = $this->graphql($this->method, ['singleUseCodes' => [$this->beam->claims[0]->singleUseCode]]);
+        $this->assertNotEmpty($response['totalCount']);
+    }
+
+    /**
+     * Test get beam with codes.
+     */
+    public function test_it_can_get_claims_with_multiple_single_use_codes(): void
+    {
+        $response = $this->graphql($this->method, ['singleUseCodes' => [$this->beam->claims[0]->singleUseCode, $this->beam->claims[1]->singleUseCode]]);
+        $this->assertNotEmpty($response['totalCount']);
+    }
+
+    /**
      * Test get beam with accounts.
      */
     public function test_it_can_get_claims_with_accounts(): void
@@ -74,15 +92,38 @@ class GetClaimsTest extends TestCaseGraphQL
      */
     public function test_will_fail_with_invalid_parameters(): void
     {
+        $codes = array_fill(0, 10, fake()->text(32));
+        $codes[0] = fake()->text(2000);
         $response = $this->graphql($this->method, [
             'ids' => [1],
-            'codes' => [fake()->text(2000)],
+            'codes' => $codes,
+            'singleUseCodes' => [fake()->text(2000)],
         ], true);
 
         $this->assertArraySubset([
             'ids' => ['The ids field prohibits codes from being present.'],
             'codes' => ['The codes field prohibits ids from being present.'],
-            'codes.0' => ['The codes.0 field must not be greater than 1024 characters.'],
+            'codes.0' => ['The codes.0 field must not be greater than 32 characters.'],
+            'singleUseCodes' => ['The single use codes field prohibits ids from being present.'],
+            'singleUseCodes.0' => ['The singleUseCodes.0 field must not be greater than 512 characters.'],
+        ], $response['error']);
+    }
+
+    /**
+     * Test get claims too many codes.
+     */
+    public function test_will_fail_with_too_many_codes(): void
+    {
+        $codes = array_fill(0, 101, fake()->text(32));
+        $singleUseCodes = array_fill(0, 101, fake()->text(384));
+        $response = $this->graphql($this->method, [
+            'codes' => $codes,
+            'singleUseCodes' => $singleUseCodes,
+        ], true);
+
+        $this->assertArraySubset([
+            'codes' => ['The codes field must not have more than 100 items.'],
+            'singleUseCodes' => ['The single use codes field must not have more than 100 items.'],
         ], $response['error']);
     }
 }

--- a/tests/Feature/GraphQL/Resources/GetClaims.graphql
+++ b/tests/Feature/GraphQL/Resources/GetClaims.graphql
@@ -1,6 +1,7 @@
 query GetClaims(
   $ids: [BigInt]
   $codes: [String]
+  $singleUseCodes: [String]
   $accounts: [String]
   $states: [ClaimStatus]
   $after: String
@@ -9,6 +10,7 @@ query GetClaims(
   GetClaims(
     ids: $ids
     codes: $codes
+    singleUseCodes: $singleUseCodes
     accounts: $accounts
     states: $states
     after: $after


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `singleUseCodes` filter to `GetClaims` query and updated validation rules.
- Created `HasSingleUseCodeScope` trait for handling single-use code scope.
- Integrated `HasSingleUseCodeScope` trait in `BeamClaim` model.
- Added validation to prevent claiming beams from multi-use codes when set to single-use.
- Added tests for `singleUseCodes` filter in `GetClaims` query.
- Added test for claiming single-use beam from multi-use code.
- Updated tests to handle invalid parameters and too many codes.
- Added `fix` script to composer scripts.
- Added `singleUseCodes` argument to GraphQL `GetClaims` query.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>mutation.php</strong><dd><code>Add description for `single_use_code` argument in mutation.</code></dd></summary>
<hr>

lang/en/mutation.php
<li>Added description for <code>single_use_code</code> argument in <code>claim_beam</code> mutation.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/74/files#diff-4f781bb4f33dedd74b3c9d8f53e97e9bfcb9dff0dd4883bc2d3338fbec35ffe3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement
</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>GetClaimsQuery.php</strong><dd><code>Add `singleUseCodes` filter and update validation rules.</code>&nbsp; </dd></summary>
<hr>

src/GraphQL/Queries/GetClaimsQuery.php
<li>Added <code>singleUseCodes</code> filter to <code>GetClaims</code> query.<br> <li> Updated validation rules for <code>codes</code> and <code>singleUseCodes</code>.<br> <li> Modified query resolution to handle <code>singleUseCodes</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/74/files#diff-c13e16e827dd73faba2e6168c5ceb215f82386841f78e7a1ced3b4eb22e61f10">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BeamClaim.php</strong><dd><code>Integrate `HasSingleUseCodeScope` trait in `BeamClaim` model.</code></dd></summary>
<hr>

src/Models/Laravel/BeamClaim.php
<li>Added <code>HasSingleUseCodeScope</code> trait to <code>BeamClaim</code> model.<br> <li> Reordered traits for better readability.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/74/files#diff-75c5b55a6305f1855fcf124dd6df0316a1cb311a1fbb1f3ca89370af6e41db42">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HasSingleUseCodeScope.php</strong><dd><code>Create `HasSingleUseCodeScope` trait.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Laravel/Traits/HasSingleUseCodeScope.php
<li>Created <code>HasSingleUseCodeScope</code> trait for handling single-use code <br>scope.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/74/files#diff-532d22067e1cfa1082b912a760eab4f56edd4173444bee5c38434f9b7caebc4e">+29/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CanClaim.php</strong><dd><code>Add validation for single-use beam claims.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Rules/CanClaim.php
<li>Added validation to prevent claiming beams from multi-use codes when <br>set to single-use.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/74/files#diff-2c15a74db77bf69b1b421f8c2518fe94df5a6341bea4efe221c593e5eca3bc80">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GetClaims.graphql</strong><dd><code>Add `singleUseCodes` argument to GraphQL query.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Resources/GetClaims.graphql
- Added `singleUseCodes` argument to `GetClaims` query.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/74/files#diff-6dc6f9b7e023d43b4cc421c8bf95385455628048a3cca8ae5cd74d1fe649ff6b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ClaimBeamTest.php</strong><dd><code>Add test for single-use beam claim validation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/ClaimBeamTest.php
- Added test for claiming single-use beam from multi-use code.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/74/files#diff-abca64f724b7b0de167a1249ce0190d78276834a2881f92efb066d6b1ae59d19">+17/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GetClaimsTest.php</strong><dd><code>Add tests for `singleUseCodes` filter and validation.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Queries/GetClaimsTest.php
<li>Added tests for <code>singleUseCodes</code> filter in <code>GetClaims</code> query.<br> <li> Updated tests to handle invalid parameters and too many codes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/74/files#diff-1b0cf59045471563e6309458630fc1bc758913f608678e89b6d495fbbbf65c0c">+43/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>composer.json</strong><dd><code>Add `fix` script to composer.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composer.json
- Added `fix` script to composer scripts.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/74/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

