### PR TITLE
[PLA-1861] Updates and tweaks for dealing with single use codes.

### DIFF
--- a/src/GraphQL/Mutations/ClaimBeamMutation.php
+++ b/src/GraphQL/Mutations/ClaimBeamMutation.php
@@ -105,7 +105,7 @@ class ClaimBeamMutation extends Mutation implements PlatformPublicGraphQlOperati
     {
         $beamCode = null;
         if ($singleUse = BeamService::isSingleUse($args['code'])) {
-            $beamCode = explode(':', decrypt($args['code']), 3)[1] ?? null;
+            $beamCode = BeamService::getSingleUseCodeData($args['code'])?->beamCode;
         }
 
         return [

--- a/src/Models/Laravel/BeamClaim.php
+++ b/src/Models/Laravel/BeamClaim.php
@@ -144,9 +144,9 @@ class BeamClaim extends BaseModel
      */
     public function scopeWithSingleUseCode(Builder $query, string $code): Builder
     {
-        $parsed = explode(':', decrypt($code), 3);
+        $parsed = BeamService::getSingleUseCodeData($code);
 
-        return $query->where(['code' => $parsed[0], 'nonce' => $parsed[2]]);
+        return $query->where(['code' => $parsed->claimCode, 'nonce' => $parsed->nonce]);
     }
 
     /**

--- a/src/Models/Laravel/Traits/HasCodeScope.php
+++ b/src/Models/Laravel/Traits/HasCodeScope.php
@@ -2,8 +2,8 @@
 
 namespace Enjin\Platform\Beam\Models\Laravel\Traits;
 
+use Enjin\Platform\Beam\Services\BeamService;
 use Illuminate\Contracts\Database\Eloquent\Builder;
-use Illuminate\Support\Arr;
 
 trait HasCodeScope
 {
@@ -12,6 +12,14 @@ trait HasCodeScope
      */
     public function scopeHasCode(Builder $query, string|array|null $code): Builder
     {
-        return $query->whereHas('beam', fn ($query) => $query->whereIn('code', Arr::wrap($code)));
+        $codes = collect($code)->map(function ($code) {
+            if (BeamService::isSingleUse($code)) {
+                return BeamService::getSingleUseCodeData($code)->beamCode;
+            }
+
+            return $code;
+        })->toArray();
+
+        return $query->whereHas('beam', fn ($query) => $query->whereIn('code', $codes));
     }
 }

--- a/src/Models/Laravel/Traits/HasSingleUseCodeScope.php
+++ b/src/Models/Laravel/Traits/HasSingleUseCodeScope.php
@@ -2,6 +2,7 @@
 
 namespace Enjin\Platform\Beam\Models\Laravel\Traits;
 
+use Enjin\Platform\Beam\Services\BeamService;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 
@@ -15,10 +16,10 @@ trait HasSingleUseCodeScope
         try {
             if (is_array($code)) {
                 $singleUseCode = array_map(function ($item) {
-                    return explode(':', decrypt($item))[0];
+                    return BeamService::getSingleUseCodeData($item)?->claimCode;
                 }, $code);
             } else {
-                $singleUseCode = explode(':', decrypt($code))[0];
+                $singleUseCode = BeamService::getSingleUseCodeData($code)?->claimCode;
             }
 
             return $query->whereIn('code', Arr::wrap($singleUseCode));

--- a/src/Rules/BeamExists.php
+++ b/src/Rules/BeamExists.php
@@ -4,6 +4,7 @@ namespace Enjin\Platform\Beam\Rules;
 
 use Closure;
 use Enjin\Platform\Beam\Models\Beam;
+use Enjin\Platform\Beam\Services\BeamService;
 use Illuminate\Contracts\Validation\ValidationRule;
 
 class BeamExists implements ValidationRule
@@ -19,6 +20,10 @@ class BeamExists implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
+        if ($beamData = BeamService::getSingleUseCodeData($value)) {
+            $value = $beamData->beamCode;
+        }
+
         if (!Beam::where($this->column, $value)->exists()) {
             $fail('validation.exists')->translate();
         }

--- a/src/Rules/CanClaim.php
+++ b/src/Rules/CanClaim.php
@@ -37,7 +37,7 @@ class CanClaim implements DataAwareRule, ValidationRule
         }
 
         if ($this->singleUse) {
-            $value = explode(':', decrypt($value), 3)[1];
+            $value = BeamService::getSingleUseCodeData($value)?->beamCode;
         } elseif (BeamService::hasSingleUse($value)) {
             $fail('enjin-platform-beam::validation.can_claim')->translate();
 

--- a/src/Rules/VerifySignedMessage.php
+++ b/src/Rules/VerifySignedMessage.php
@@ -38,7 +38,7 @@ class VerifySignedMessage implements DataAwareRule, ValidationRule
         }
 
         if (BeamService::isSingleUse($this->data['code'])) {
-            $this->data['code'] = explode(':', decrypt($this->data['code']))[1];
+            $this->data['code'] = BeamService::getSingleUseCodeData($this->data['code'])?->beamCode;
         }
 
         if (!$scan = BeamScan::hasCode($this->data['code'])->firstWhere(['wallet_public_key' => $publicKey])) {

--- a/src/Services/BeamService.php
+++ b/src/Services/BeamService.php
@@ -305,12 +305,22 @@ class BeamService
             return false;
         }
 
+        return static::hasSingleUse(static::getSingleUseCodeData($code)?->beamCode);
+    }
+
+    public static function getSingleUseCodeData(string $code): ?object
+    {
         try {
-            return static::hasSingleUse(explode(':', decrypt($code), 3)[1] ?? null);
+            [$claimCode, $beamCode, $nonce] = explode(':', decrypt($code), 3);
         } catch (Throwable) {
+            return null;
         }
 
-        return false;
+        return json_decode(json_encode([
+            'claimCode' => $claimCode,
+            'beamCode' => $beamCode,
+            'nonce' => $nonce,
+        ]));
     }
 
     /**

--- a/src/Services/BeamService.php
+++ b/src/Services/BeamService.php
@@ -312,15 +312,15 @@ class BeamService
     {
         try {
             [$claimCode, $beamCode, $nonce] = explode(':', decrypt($code), 3);
+
+            return (object) [
+                'claimCode' => $claimCode,
+                'beamCode' => $beamCode,
+                'nonce' => $nonce,
+            ];
         } catch (Throwable) {
             return null;
         }
-
-        return json_decode(json_encode([
-            'claimCode' => $claimCode,
-            'beamCode' => $beamCode,
-            'nonce' => $nonce,
-        ]));
     }
 
     /**

--- a/tests/Feature/GraphQL/Queries/GetPendingClaimsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetPendingClaimsTest.php
@@ -43,6 +43,24 @@ class GetPendingClaimsTest extends TestCaseGraphQL
     }
 
     /**
+     * Test get claims from single use code.
+     */
+    public function test_it_can_get_pending_claims_using_single_use_code(): void
+    {
+        $response = $this->graphql($this->method, [
+            'code' => $this->beam->claims[0]->single_use_code,
+            'account' => $this->claims->first()->wallet_public_key,
+        ]);
+        $this->assertNotEmpty($response['totalCount']);
+
+        $response = $this->graphql($this->method, [
+            'code' => $this->beam->claims[0]->single_use_code,
+            'account' => resolve(SubstrateProvider::class)->public_key(),
+        ]);
+        $this->assertEmpty($response['edges']);
+    }
+
+    /**
      * Test get claims with id and code.
      */
     public function test_will_fail_with_invalid_parameters(): void


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored various parts of the codebase to handle single-use codes using the new `BeamService::getSingleUseCodeData` method.
- Enhanced validation rules to support single-use codes.
- Added a new test case to verify the functionality of pending claims using single-use codes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ClaimBeamMutation.php</strong><dd><code>Refactor single-use code handling in ClaimBeamMutation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Mutations/ClaimBeamMutation.php
<li>Replaced decryption logic with <code>BeamService::getSingleUseCodeData</code> for <br>single-use codes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/75/files#diff-f4080d41dd3f655ad87332d52f8518891a8259c17242a35f41dd2fd3c8756bbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GetPendingClaimsQuery.php</strong><dd><code>Enhance single-use code handling and validation in </code><br><code>GetPendingClaimsQuery</code></dd></summary>
<hr>

src/GraphQL/Queries/GetPendingClaimsQuery.php
<li>Added <code>BeamService::getSingleUseCodeData</code> to handle single-use codes.<br> <li> Updated validation rules to use <code>BeamExists</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/75/files#diff-7b218662697e9b8f0c5e67c057954e3b0978018c4e49d7af92711119277ea9ed">+15/-2</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BeamClaim.php</strong><dd><code>Refactor single-use code handling in BeamClaim model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Laravel/BeamClaim.php
<li>Replaced decryption logic with <code>BeamService::getSingleUseCodeData</code> in <br><code>scopeWithSingleUseCode</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/75/files#diff-75c5b55a6305f1855fcf124dd6df0316a1cb311a1fbb1f3ca89370af6e41db42">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HasCodeScope.php</strong><dd><code>Enhance single-use code handling in HasCodeScope trait</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Models/Laravel/Traits/HasCodeScope.php
<li>Added logic to handle single-use codes using <br><code>BeamService::getSingleUseCodeData</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/75/files#diff-6db7ea4a773af7f9382c97cf299273e77bb15d469cb0f28fc2f2f57cd5e6b93e">+10/-2</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HasSingleUseCodeScope.php</strong><dd><code>Refactor single-use code handling in HasSingleUseCodeScope trait</code></dd></summary>
<hr>

src/Models/Laravel/Traits/HasSingleUseCodeScope.php
<li>Replaced decryption logic with <code>BeamService::getSingleUseCodeData</code> for <br>single-use codes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/75/files#diff-532d22067e1cfa1082b912a760eab4f56edd4173444bee5c38434f9b7caebc4e">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BeamExists.php</strong><dd><code>Enhance BeamExists rule to handle single-use codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Rules/BeamExists.php
<li>Added logic to handle single-use codes using <br><code>BeamService::getSingleUseCodeData</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/75/files#diff-8628f43221dfd049489f0faf3732301c136f5840575ff0ad5e7712397c3cbd57">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CanClaim.php</strong><dd><code>Refactor single-use code handling in CanClaim rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Rules/CanClaim.php
<li>Replaced decryption logic with <code>BeamService::getSingleUseCodeData</code> for <br>single-use codes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/75/files#diff-2c15a74db77bf69b1b421f8c2518fe94df5a6341bea4efe221c593e5eca3bc80">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>VerifySignedMessage.php</strong><dd><code>Refactor single-use code handling in VerifySignedMessage rule</code></dd></summary>
<hr>

src/Rules/VerifySignedMessage.php
<li>Replaced decryption logic with <code>BeamService::getSingleUseCodeData</code> for <br>single-use codes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/75/files#diff-2de4d569877788e89207b28485f4a42feba9eed4e40557b368d5371d8731cc34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BeamService.php</strong><dd><code>Add and utilize getSingleUseCodeData method in BeamService</code></dd></summary>
<hr>

src/Services/BeamService.php
<li>Added <code>getSingleUseCodeData</code> method to handle single-use code parsing.<br> <li> Updated <code>isSingleUse</code> method to use <code>getSingleUseCodeData</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/75/files#diff-ad61fe9557d8825aa83df9c1b4f43f366501cc39578bb179cc229a0defca6578">+12/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>GetPendingClaimsTest.php</strong><dd><code>Add test for pending claims with single-use code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Queries/GetPendingClaimsTest.php
- Added test for getting pending claims using single-use code.



</details>
    

  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/75/files#diff-a1dc2e5a546ca88653b7714df3124503659383e45c9ba5632b2d065b87d71e0f">+18/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

