### PR TITLE
[PLA-1891] Hide sensitive attributes from beam APIs

### DIFF
--- a/src/GraphQL/Queries/GetBeamQuery.php
+++ b/src/GraphQL/Queries/GetBeamQuery.php
@@ -8,12 +8,13 @@ use Enjin\Platform\Beam\Models\Beam;
 use Enjin\Platform\Beam\Rules\ScanLimit;
 use Enjin\Platform\Beam\Rules\SingleUseCodeExist;
 use Enjin\Platform\Beam\Services\BeamService;
+use Enjin\Platform\Interfaces\PlatformPublicGraphQlOperation;
 use Enjin\Platform\Rules\ValidSubstrateAccount;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
-class GetBeamQuery extends Query
+class GetBeamQuery extends Query implements PlatformPublicGraphQlOperation
 {
     use HasBeamCommonFields;
 

--- a/src/GraphQL/Queries/GetBeamQuery.php
+++ b/src/GraphQL/Queries/GetBeamQuery.php
@@ -8,13 +8,12 @@ use Enjin\Platform\Beam\Models\Beam;
 use Enjin\Platform\Beam\Rules\ScanLimit;
 use Enjin\Platform\Beam\Rules\SingleUseCodeExist;
 use Enjin\Platform\Beam\Services\BeamService;
-use Enjin\Platform\Interfaces\PlatformPublicGraphQlOperation;
 use Enjin\Platform\Rules\ValidSubstrateAccount;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
-class GetBeamQuery extends Query implements PlatformPublicGraphQlOperation
+class GetBeamQuery extends Query
 {
     use HasBeamCommonFields;
 

--- a/src/GraphQL/Queries/GetBeamsQuery.php
+++ b/src/GraphQL/Queries/GetBeamsQuery.php
@@ -8,13 +8,12 @@ use Enjin\Platform\Beam\Models\Beam;
 use Enjin\Platform\Beam\Services\BeamService;
 use Enjin\Platform\GraphQL\Middleware\ResolvePage;
 use Enjin\Platform\GraphQL\Types\Pagination\ConnectionInput;
-use Enjin\Platform\Interfaces\PlatformPublicGraphQlOperation;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
 use Illuminate\Support\Arr;
 use Rebing\GraphQL\Support\Facades\GraphQL;
 
-class GetBeamsQuery extends Query implements PlatformPublicGraphQlOperation
+class GetBeamsQuery extends Query
 {
     use HasBeamCommonFields;
 

--- a/src/GraphQL/Types/BeamType.php
+++ b/src/GraphQL/Types/BeamType.php
@@ -7,6 +7,7 @@ use Enjin\Platform\Beam\Enums\BeamFlag;
 use Enjin\Platform\Beam\GraphQL\Traits\HasBeamCommonFields;
 use Enjin\Platform\Beam\Models\Beam;
 use Enjin\Platform\Beam\Services\BeamService;
+use Enjin\Platform\GraphQL\Schemas\Traits\HasAuthorizableFields;
 use Enjin\Platform\GraphQL\Types\Pagination\ConnectionInput;
 use Enjin\Platform\Traits\HasSelectFields;
 use Illuminate\Pagination\Cursor;
@@ -17,6 +18,7 @@ use Rebing\GraphQL\Support\Facades\GraphQL;
 
 class BeamType extends Type
 {
+    use HasAuthorizableFields;
     use HasBeamCommonFields;
     use HasSelectFields;
 
@@ -45,6 +47,7 @@ class BeamType extends Type
             'code' => [
                 'type' => GraphQL::type('String!'),
                 'description' => __('enjin-platform-beam::mutation.claim_beam.args.code'),
+                'excludeFrom' => ['GetBeam', 'GetBeams'],
             ],
             ...$this->getCommonFields(),
             'collection' => [
@@ -89,6 +92,7 @@ class BeamType extends Type
                 },
                 'selectable' => false,
                 'is_relation' => false,
+                'excludeFrom' => ['GetBeam', 'GetBeams'],
             ],
             'probabilities' => [
                 'type' => GraphQL::type('Object'),

--- a/tests/Feature/GraphQL/Queries/GetBeamTest.php
+++ b/tests/Feature/GraphQL/Queries/GetBeamTest.php
@@ -179,7 +179,7 @@ class GetBeamTest extends TestCaseGraphQL
         ]);
 
         $response = $this->graphql($this->method, ['code' => $this->beam->code], true);
-        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', $response['error']);
+        $this->assertEquals('Cannot query field "code" on type "Beam".', $response['error']);
 
         config([
             'enjin-platform.auth' => null,

--- a/tests/Feature/GraphQL/Queries/GetBeamsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetBeamsTest.php
@@ -96,7 +96,7 @@ class GetBeamsTest extends TestCaseGraphQL
         ]);
 
         $response = $this->graphql($this->method, [], true);
-        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', $response['error']);
+        $this->assertEquals('Cannot query field "code" on type "Beam".', $response['error']);
 
         config([
             'enjin-platform.auth' => null,


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Removed the implementation of `PlatformPublicGraphQlOperation` interface from `GetBeamQuery` and `GetBeamsQuery` classes.
- Adjusted class definitions to make the beam APIs private.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GetBeamQuery.php</strong><dd><code>Make GetBeamQuery class private by removing interface</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Queries/GetBeamQuery.php

<li>Removed implementation of <code>PlatformPublicGraphQlOperation</code> interface.<br> <li> Adjusted class definition accordingly.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/85/files#diff-94c4eff1889e3d1b21a48414342f286b17b3ec30884c40eefc970ff300413d26">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GetBeamsQuery.php</strong><dd><code>Make GetBeamsQuery class private by removing interface</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Queries/GetBeamsQuery.php

<li>Removed implementation of <code>PlatformPublicGraphQlOperation</code> interface.<br> <li> Adjusted class definition accordingly.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/85/files#diff-f36230acc49e0931f3d0f65650a34c46f35b170d876ecb77199f1c7b3394ba2c">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

