### PR TITLE
[PLA-1896] Fix validation create beam on mint on demand

### DIFF
--- a/src/GraphQL/Mutations/CreateBeamMutation.php
+++ b/src/GraphQL/Mutations/CreateBeamMutation.php
@@ -8,11 +8,9 @@ use Enjin\Platform\Beam\GraphQL\Traits\HasBeamCommonFields;
 use Enjin\Platform\Beam\Rules\MaxTokenCount;
 use Enjin\Platform\Beam\Rules\MaxTokenSupply;
 use Enjin\Platform\Beam\Rules\TokensDoNotExistInBeam;
-use Enjin\Platform\Beam\Rules\TokensDoNotExistInCollection;
 use Enjin\Platform\Beam\Rules\TokensExistInCollection;
 use Enjin\Platform\Beam\Rules\TokenUploadExistInCollection;
 use Enjin\Platform\Beam\Rules\TokenUploadNotExistInBeam;
-use Enjin\Platform\Beam\Rules\TokenUploadNotExistInCollection;
 use Enjin\Platform\Beam\Rules\UniqueTokenIds;
 use Enjin\Platform\Beam\Services\BeamService;
 use Enjin\Platform\Models\Collection;
@@ -132,7 +130,7 @@ class CreateBeamMutation extends Mutation
                     'distinct',
                     BeamType::getEnumCase(Arr::get($args, str_replace('tokenIds', 'type', $attribute))) == BeamType::TRANSFER_TOKEN
                         ? new TokensExistInCollection($args['collectionId'])
-                        : new TokensDoNotExistInCollection($args['collectionId']),
+                        : '',
                     new TokensDoNotExistInBeam(),
                 ];
             }),
@@ -143,7 +141,7 @@ class CreateBeamMutation extends Mutation
                     'prohibits:tokens.*.tokenIds',
                     BeamType::getEnumCase(Arr::get($args, str_replace('tokenIdDataUpload', 'type', $attribute))) == BeamType::TRANSFER_TOKEN
                         ? new TokenUploadExistInCollection($args['collectionId'])
-                        : new TokenUploadNotExistInCollection($args['collectionId']),
+                        : '',
                     new TokenUploadNotExistInBeam(),
                 ];
             }),

--- a/tests/Feature/GraphQL/Mutations/CreateBeamTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateBeamTest.php
@@ -96,26 +96,6 @@ class CreateBeamTest extends TestCaseGraphQL
      */
     public function test_it_will_fail_to_create_beam_with_invalid_file_upload(): void
     {
-        $file = UploadedFile::fake()->createWithContent('tokens.txt', $this->token->token_chain_id);
-        $response = $this->graphql($this->method, array_merge(
-            $this->generateBeamData(),
-            ['tokens' => [['tokenIdDataUpload' => $file, 'type' => BeamType::MINT_ON_DEMAND->name]]]
-        ), true);
-        $this->assertArraySubset([
-            'tokens.0.tokenIdDataUpload' => ['The tokens.0.tokenIdDataUpload exists in the specified collection.'],
-        ], $response['error']);
-        Event::assertNotDispatched(BeamCreated::class);
-
-        $file = UploadedFile::fake()->createWithContent('tokens.txt', "{$this->token->token_chain_id}..{$this->token->token_chain_id}");
-        $response = $this->graphql($this->method, array_merge(
-            $this->generateBeamData(),
-            ['tokens' => [['tokenIdDataUpload' => $file, 'type' => BeamType::MINT_ON_DEMAND->name]]]
-        ), true);
-        $this->assertArraySubset([
-            'tokens.0.tokenIdDataUpload' => ['The tokens.0.tokenIdDataUpload exists in the specified collection.'],
-        ], $response['error']);
-        Event::assertNotDispatched(BeamCreated::class);
-
         $file = UploadedFile::fake()->createWithContent('tokens.txt', '1');
         $response = $this->graphql($this->method, array_merge(
             $this->generateBeamData(),
@@ -135,24 +115,6 @@ class CreateBeamTest extends TestCaseGraphQL
             'tokens.0.tokenIdDataUpload' => ['The tokens.0.tokenIdDataUpload does not exist in the specified collection.'],
         ], $response['error']);
         Event::assertNotDispatched(BeamCreated::class);
-    }
-
-    /**
-     * Test creating beam token exist in collection.
-     */
-    public function test_it_will_fail_with_token_exist(): void
-    {
-        $response = $this->graphql(
-            $this->method,
-            array_merge(
-                $this->generateBeamData(BeamType::MINT_ON_DEMAND),
-                ['tokens' => [['tokenIds' => [$this->token->token_chain_id], 'type' => BeamType::MINT_ON_DEMAND->name]]]
-            ),
-            true
-        );
-        $this->assertArraySubset([
-            'tokens.0.tokenIds' => ['The tokens.0.tokenIds exists in the specified collection.'],
-        ], $response['error']);
     }
 
     /**


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Removed validation rules `TokensDoNotExistInCollection` and `TokenUploadNotExistInCollection` from `CreateBeamMutation`.
- Updated conditional logic to handle cases where these validation rules were previously applied.
- Removed corresponding tests for token existence in collection validation from `CreateBeamTest`.
- Simplified the test for invalid file upload in `CreateBeamTest`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateBeamMutation.php</strong><dd><code>Remove redundant token existence validation rules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Mutations/CreateBeamMutation.php

<li>Removed validation rules <code>TokensDoNotExistInCollection</code> and <br><code>TokenUploadNotExistInCollection</code>.<br> <li> Updated conditional logic to handle empty validation rules.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/86/files#diff-7854b3fc25813803a4271cafe9cda209a7719d4c6493b48db43f6d02475e4b10">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateBeamTest.php</strong><dd><code>Remove tests for redundant token existence validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/CreateBeamTest.php

<li>Removed tests related to token existence in collection validation.<br> <li> Simplified test for invalid file upload.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/86/files#diff-6cb75a11c831dd0307af26db7041d6d8a9362c7931f3e3483a7731edb72b9ee6">+0/-38</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

