### PR TITLE
[PLA-1899] Expose qr and code for get beam

### DIFF
--- a/src/GraphQL/Types/BeamType.php
+++ b/src/GraphQL/Types/BeamType.php
@@ -47,7 +47,6 @@ class BeamType extends Type
             'code' => [
                 'type' => GraphQL::type('String!'),
                 'description' => __('enjin-platform-beam::mutation.claim_beam.args.code'),
-                'excludeFrom' => ['GetBeam', 'GetBeams'],
             ],
             ...$this->getCommonFields(),
             'collection' => [
@@ -92,7 +91,6 @@ class BeamType extends Type
                 },
                 'selectable' => false,
                 'is_relation' => false,
-                'excludeFrom' => ['GetBeam', 'GetBeams'],
             ],
             'probabilities' => [
                 'type' => GraphQL::type('Object'),

--- a/tests/Feature/GraphQL/Queries/GetBeamTest.php
+++ b/tests/Feature/GraphQL/Queries/GetBeamTest.php
@@ -179,7 +179,7 @@ class GetBeamTest extends TestCaseGraphQL
         ]);
 
         $response = $this->graphql($this->method, ['code' => $this->beam->code], true);
-        $this->assertEquals('Cannot query field "code" on type "Beam".', $response['error']);
+        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', $response['error']);
 
         config([
             'enjin-platform.auth' => null,

--- a/tests/Feature/GraphQL/Queries/GetBeamsTest.php
+++ b/tests/Feature/GraphQL/Queries/GetBeamsTest.php
@@ -96,7 +96,7 @@ class GetBeamsTest extends TestCaseGraphQL
         ]);
 
         $response = $this->graphql($this->method, [], true);
-        $this->assertEquals('Cannot query field "code" on type "Beam".', $response['error']);
+        $this->assertEquals('Cannot query field "code" on type "BeamClaim".', $response['error']);
 
         config([
             'enjin-platform.auth' => null,


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed the 'excludeFrom' attribute for the 'code' and 'qr' fields in the `BeamType` class to simplify the field definitions.
- This change ensures that the 'code' and 'qr' fields are now included in the 'GetBeam' and 'GetBeams' queries.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BeamType.php</strong><dd><code>Simplify BeamType fields by removing 'excludeFrom' attributes</code></dd></summary>
<hr>

src/GraphQL/Types/BeamType.php

<li>Removed 'excludeFrom' attribute for 'code' and 'qr' fields in the <br>BeamType class.<br> <li> Simplified the fields definition by excluding unnecessary attributes.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/87/files#diff-53e71a165bbd916dd45d06a59976aa3aa5ca249d9732f5ae390b4de587f2179a">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

