### PR TITLE
[PLA-1907] Fixes Beam transactions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.2|^8.3",
         "ext-bcmath": "*",
         "ext-json": "*",
         "ext-openssl": "*",
         "enjin/platform-core": "*",
         "phrity/websocket": "^1.0",
-        "rebing/graphql-laravel": "^9.2",
+        "rebing/graphql-laravel": "^9.0",
         "spatie/laravel-package-tools": "^1.0",
         "spatie/laravel-ray": "^1.0"
     },
@@ -72,8 +72,8 @@
     "prefer-stable": false,
     "require-dev": {
         "dms/phpunit-arraysubset-asserts": "dev-master",
-        "laravel/pint": "^1.16",
-        "nunomaduro/collision": "^8.1",
+        "laravel/pint": "^1.0",
+        "nunomaduro/collision": "^8.0",
         "larastan/larastan": "^2.0",
         "orchestra/testbench": "^9.0",
         "phpstan/extension-installer": "^1.0",

--- a/src/Commands/BatchProcess.php
+++ b/src/Commands/BatchProcess.php
@@ -206,7 +206,7 @@ class BatchProcess extends Command
                 foreach ($params as $param) {
                     $transaction = $this->transaction->store([
                         'method' => $method,
-                        'encoded_data' => $this->serialize->encode($method, [
+                        'encoded_data' => $this->serialize->encode(isRunningLatest() ? $method . 'V1010' : $method, [
                             'collectionId' => $param['collectionId'],
                             'recipients' => $param['recipients'],
                         ]),


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed a bug in `BatchProcess.php` by conditionally appending 'V1010' to the method name in the `encoded_data` field based on the `isRunningLatest()` function.
- Updated `composer.json` to:
  - Include PHP version ^8.3.
  - Downgrade `rebing/graphql-laravel` dependency version.
  - Adjust versions for `laravel/pint` and `nunomaduro/collision` in `require-dev`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BatchProcess.php</strong><dd><code>Conditional method name modification in transaction encoding</code></dd></summary>
<hr>

src/Commands/BatchProcess.php

<li>Modified the <code>encoded_data</code> field to append 'V1010' to the method name <br>if <code>isRunningLatest()</code> returns true.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/88/files#diff-343dcc3cf53276d2abb4f91c758dd786dd829a75de65f5d27ff508685b6598ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>composer.json</strong><dd><code>Update dependencies and PHP version requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composer.json

<li>Updated PHP version requirement to include ^8.3.<br> <li> Downgraded <code>rebing/graphql-laravel</code> dependency version.<br> <li> Adjusted versions for <code>laravel/pint</code> and <code>nunomaduro/collision</code> in <br><code>require-dev</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/88/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

