### PR TITLE
[PLA-1414] Fix typo in translation string key.

### DIFF
--- a/src/GraphQL/Types/BeamScanType.php
+++ b/src/GraphQL/Types/BeamScanType.php
@@ -34,7 +34,7 @@ class BeamScanType extends Type
             ],
             'walletPublicKey' => [
                 'type' => GraphQL::type('String!'),
-                'description' => __('enjin-platform-beam::type.beam_scan.field.walletPublicKe'),
+                'description' => __('enjin-platform-beam::type.beam_scan.field.walletPublicKey'),
                 'alias' => 'wallet_public_key',
             ],
             'message' => [


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a typo in the translation string key for `walletPublicKey` description in `BeamScanType.php`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BeamScanType.php</strong><dd><code>Fix typo in translation string key for walletPublicKey</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/GraphQL/Types/BeamScanType.php

<li>Fixed a typo in the translation string key for <code>walletPublicKey</code> <br>description.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/91/files#diff-5d73f7589d85484cc692a8d2da7ca0bc7178a0b1554925d1cfd6eec3ea39b385">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

