### PR TITLE
[PLA-1970] Stop RemoveClaimToken from being run on Token Transferred events.

### DIFF
--- a/src/BeamServiceProvider.php
+++ b/src/BeamServiceProvider.php
@@ -59,7 +59,8 @@ class BeamServiceProvider extends PackageServiceProvider
         Event::listen(TransactionUpdated::class, UpdateClaimStatus::class);
         Event::listen(TokenBurned::class, RemoveClaimToken::class);
         Event::listen(TokenDestroyed::class, RemoveClaimToken::class);
-        Event::listen(TokenTransferred::class, RemoveClaimToken::class);
+        // TODO: Uncomment this line after improving the RemoveClaimToken listener
+        // Event::listen(TokenTransferred::class, RemoveClaimToken::class);
         Event::listen(CollectionFrozen::class, PauseBeam::class);
         Event::listen(CollectionThawed::class, UnpauseBeam::class);
         Event::listen(CollectionDestroyed::class, ExpireBeam::class);


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Commented out the `RemoveClaimToken` listener for `TokenTransferred` events to prevent it from being executed.
- Added a TODO note to indicate that the `RemoveClaimToken` listener needs improvement before it can be re-enabled.
- Please note that some beam claim data may become invalidated and claims will fail for tokens allocated to the beam that are transferred outside of the beam system and therefore are no longer under the control of the beam owner's wallet.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BeamServiceProvider.php</strong><dd><code>Comment out RemoveClaimToken listener for TokenTransferred events</code></dd></summary>
<hr>

src/BeamServiceProvider.php

<li>Commented out the <code>RemoveClaimToken</code> listener for <code>TokenTransferred</code> <br>events.<br> <li> Added a TODO note to revisit the <code>RemoveClaimToken</code> listener.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/94/files#diff-f80ec4f5b8eb2dc8bb7dc8a8f97ef0d7f175b93fe432c748e3d4861424395d2e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

