### PR TITLE
[PLA-1970] Optimize remove claim token listener

### DIFF
--- a/src/Listeners/RemoveClaimToken.php
+++ b/src/Listeners/RemoveClaimToken.php
@@ -38,7 +38,7 @@ class RemoveClaimToken implements ShouldQueue
                 ->delete();
 
             Beam::whereIn('id', $beamsToDecrement)
-                ->get(['id,code'])
+                ->get(['id', 'code'])
                 ->each(fn ($beam) => Cache::decrement(BeamService::key($beam->code)));
         }
 

--- a/src/Listeners/RemoveClaimToken.php
+++ b/src/Listeners/RemoveClaimToken.php
@@ -18,7 +18,13 @@ class RemoveClaimToken implements ShouldQueue
      */
     public function handle(PlatformBroadcastEvent $event): void
     {
-        if (!$collection = Collection::where('collection_chain_id', $event->broadcastData['collectionId'])->first()) {
+        $collection = Cache::remember(
+            'collection:' . $event->broadcastData['collectionId'],
+            30,
+            fn () => Collection::where('collection_chain_id', $event->broadcastData['collectionId'])->first(['id'])
+        );
+
+        if (!$collection) {
             return;
         }
 
@@ -29,17 +35,19 @@ class RemoveClaimToken implements ShouldQueue
         ) {
             $beamsToDecrement = BeamClaim::where('token_chain_id', $event->broadcastData['tokenId'])
                 ->where('collection_id', $collection->id)
+                ->selectRaw('beam_id, count(*) total')
                 ->claimable()
-                ->pluck('beam_id');
+                ->groupBy('beam_id')
+                ->pluck('total', 'beam_id');
 
             BeamClaim::where('token_chain_id', $event->broadcastData['tokenId'])
                 ->where('collection_id', $collection->id)
                 ->claimable()
                 ->delete();
 
-            Beam::whereIn('id', $beamsToDecrement)
+            Beam::whereIn('id', $beamsToDecrement->keys())
                 ->get(['id', 'code'])
-                ->each(fn ($beam) => Cache::decrement(BeamService::key($beam->code)));
+                ->each(fn ($beam) => Cache::decrement(BeamService::key($beam->code), $beamsToDecrement[$beam->id]));
         }
 
 

--- a/src/Listeners/RemoveClaimToken.php
+++ b/src/Listeners/RemoveClaimToken.php
@@ -2,9 +2,12 @@
 
 namespace Enjin\Platform\Beam\Listeners;
 
+use Enjin\Platform\Beam\Models\Beam;
 use Enjin\Platform\Beam\Models\BeamClaim;
 use Enjin\Platform\Beam\Services\BeamService;
 use Enjin\Platform\Events\PlatformBroadcastEvent;
+use Enjin\Platform\Models\Collection;
+use Enjin\Platform\Models\Token;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Cache;
 
@@ -15,21 +18,30 @@ class RemoveClaimToken implements ShouldQueue
      */
     public function handle(PlatformBroadcastEvent $event): void
     {
-        BeamClaim::where('token_chain_id', $event->broadcastData['tokenId'])
-            ->whereHas(
-                'collection',
-                fn ($query) => $query->where('collection_chain_id', $event->broadcastData['collectionId'])
-            )
-            ->claimable()
-            ->with('beam')
-            ->get()
-            ->each(function ($claim) {
-                if ($claim->token?->nonFungible) {
-                    $claim->delete();
-                    if ($code = $claim?->beam?->code) {
-                        Cache::decrement(BeamService::key($code));
-                    }
-                }
-            });
+        if (!$collection = Collection::where('collection_chain_id', $event->broadcastData['collectionId'])->first()) {
+            return;
+        }
+
+        if (Token::where('collection_id', $collection->id)
+            ->where('token_chain_id', $event->broadcastData['tokenId'])
+            ->first()
+            ?->nonFungible
+        ) {
+            $beamsToDecrement = BeamClaim::where('token_chain_id', $event->broadcastData['tokenId'])
+                ->where('collection_id', $collection->id)
+                ->claimable()
+                ->pluck('beam_id');
+
+            BeamClaim::where('token_chain_id', $event->broadcastData['tokenId'])
+                ->where('collection_id', $collection->id)
+                ->claimable()
+                ->delete();
+
+            Beam::whereIn('id', $beamsToDecrement)
+                ->get(['id,code'])
+                ->each(fn ($beam) => Cache::decrement(BeamService::key($beam->code)));
+        }
+
+
     }
 }

--- a/src/Listeners/RemoveClaimToken.php
+++ b/src/Listeners/RemoveClaimToken.php
@@ -29,7 +29,7 @@ class RemoveClaimToken implements ShouldQueue
         }
 
         $key = 'RemoveClaimToken:' . $collectionId . ':' . $event->broadcastData['tokenId'];
-        Cache::lock($key)->get(function () use ($event, $collectionId) {
+        Cache::lock($key, 5)->get(function () use ($event, $collectionId) {
             if (Token::where('collection_id', $collectionId)
                 ->where('token_chain_id', $event->broadcastData['tokenId'])
                 ->first()


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `RemoveClaimToken` listener by adding checks for the existence of a collection before proceeding with token operations.
- Optimized the logic for handling token and beam claims, improving performance and readability.
- Replaced the `each` method with more efficient query operations to handle beam claims and cache decrements.
- Improved the cache decrement logic by directly working with beam codes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoveClaimToken.php</strong><dd><code>Optimize and enhance the RemoveClaimToken listener logic</code>&nbsp; </dd></summary>
<hr>

src/Listeners/RemoveClaimToken.php

<li>Added checks for collection existence before proceeding.<br> <li> Optimized token and beam claim handling logic.<br> <li> Replaced <code>each</code> with more efficient query operations.<br> <li> Improved cache decrement logic for beams.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/95/files#diff-464530882c42cf7047e47cd7a5d40e86162c51ae1eebf20ca7c4208cd017753a">+28/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

