### PR TITLE
[PLA-1965] Fix freeze collection

### DIFF
--- a/src/Listeners/PauseBeam.php
+++ b/src/Listeners/PauseBeam.php
@@ -2,7 +2,9 @@
 
 namespace Enjin\Platform\Beam\Listeners;
 
+use Enjin\Platform\Beam\Enums\BeamType;
 use Enjin\Platform\Beam\Models\Beam;
+use Enjin\Platform\Beam\Models\BeamClaim;
 use Enjin\Platform\Beam\Services\BeamService;
 use Enjin\Platform\Events\PlatformBroadcastEvent;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -15,15 +17,26 @@ class PauseBeam implements ShouldQueue
      */
     public function handle(PlatformBroadcastEvent $event): void
     {
-        Beam::where('collection_chain_id', $event->broadcastData['collectionId'])
-            ->get()
-            ->each(function ($beam) {
-                $beam->update(['flags_mask' => BeamService::getFlagsValue(
-                    collect(array_merge($beam->flags ?? [], ['PAUSED']))
-                        ->unique()
-                        ->map(fn ($flag) => ['flag' => $flag, 'enabled' => true])->all()
-                )]);
-                Log::info("Pausing beam {$beam->code} cause the collection {$beam->collection_chain_id} was paused.");
-            });
+        foreach (Beam::where('collection_chain_id', $event->broadcastData['collectionId'])->get() as $beam) {
+            $hasTransfers = BeamClaim::claimable()
+                ->where('type', BeamType::TRANSFER_TOKEN->name)
+                ->where('beam_id', $beam->id)
+                ->exists();
+            $hasMints = BeamClaim::claimable()
+                ->where('type', BeamType::MINT_ON_DEMAND->name)
+                ->where('beam_id', $beam->id)
+                ->exists();
+            if (($hasMints && !$hasTransfers) || ($hasMints && $hasTransfers)) {
+                continue;
+            }
+
+            $beam->update(['flags_mask' => BeamService::getFlagsValue(
+                collect(array_merge($beam->flags ?? [], ['PAUSED']))
+                    ->unique()
+                    ->map(fn ($flag) => ['flag' => $flag, 'enabled' => true])->all()
+            )]);
+
+            Log::info("Pausing beam {$beam->code} cause the collection {$beam->collection_chain_id} was paused.");
+        }
     }
 }

--- a/src/Listeners/PauseBeam.php
+++ b/src/Listeners/PauseBeam.php
@@ -18,15 +18,11 @@ class PauseBeam implements ShouldQueue
     public function handle(PlatformBroadcastEvent $event): void
     {
         foreach (Beam::where('collection_chain_id', $event->broadcastData['collectionId'])->get() as $beam) {
-            $hasTransfers = BeamClaim::claimable()
-                ->where('type', BeamType::TRANSFER_TOKEN->name)
-                ->where('beam_id', $beam->id)
-                ->exists();
-            $hasMints = BeamClaim::claimable()
+            if (BeamClaim::claimable()
                 ->where('type', BeamType::MINT_ON_DEMAND->name)
                 ->where('beam_id', $beam->id)
-                ->exists();
-            if (($hasMints && !$hasTransfers) || ($hasMints && $hasTransfers)) {
+                ->exists()
+            ) {
                 continue;
             }
 

--- a/tests/Feature/GraphQL/Mutations/ClaimBeamTest.php
+++ b/tests/Feature/GraphQL/Mutations/ClaimBeamTest.php
@@ -9,6 +9,7 @@ use Enjin\Platform\Beam\Enums\BeamFlag;
 use Enjin\Platform\Beam\Enums\BeamType;
 use Enjin\Platform\Beam\Events\BeamClaimPending;
 use Enjin\Platform\Beam\Jobs\ClaimBeam;
+use Enjin\Platform\Beam\Listeners\PauseBeam;
 use Enjin\Platform\Beam\Models\BeamClaim;
 use Enjin\Platform\Beam\Rules\PassesClaimConditions;
 use Enjin\Platform\Beam\Services\BatchService;
@@ -16,11 +17,14 @@ use Enjin\Platform\Beam\Tests\Feature\GraphQL\TestCaseGraphQL;
 use Enjin\Platform\Beam\Tests\Feature\Traits\CreateBeamData;
 use Enjin\Platform\Beam\Tests\Feature\Traits\SeedBeamData;
 use Enjin\Platform\Enums\Substrate\CryptoSignatureType;
+use Enjin\Platform\Events\Substrate\MultiTokens\CollectionFrozen;
 use Enjin\Platform\Providers\Faker\SubstrateProvider;
 use Enjin\Platform\Services\Database\WalletService;
+use Enjin\Platform\Services\Processor\Substrate\Codec\Polkadart\Events\MultiTokens\Frozen;
 use Enjin\Platform\Support\Account;
 use Enjin\Platform\Support\BitMask;
 use Enjin\Platform\Support\SS58Address;
+use Faker\Generator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
@@ -507,5 +511,104 @@ class ClaimBeamTest extends TestCaseGraphQL
 
         Queue::assertPushed(ClaimBeam::class);
         Event::assertDispatched(BeamClaimPending::class);
+    }
+
+
+    public function test_it_can_claim_mint_on_demand_with_frozen_collection()
+    {
+        $this->seedBeam(1, false, BeamType::MINT_ON_DEMAND);
+        $this->collection->update(['is_frozen' => true]);
+        $event = Frozen::fromChain([
+            'phase' => ['ApplyExtrinsic' => 1],
+            'event' => [
+                'MultiTokens' => [
+                    'Frozen' => [
+                        'FreezeOf<T>' => [
+                            'collection_id' => $this->collection->collection_chain_id,
+                            'freeze_type' => ['Collection' => []],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        resolve(PauseBeam::class)->handle(new CollectionFrozen($event));
+        $this->assertFalse($this->beam->refresh()->hasFlag(BeamFlag::PAUSED));
+
+        $response = $this->graphql($this->method, [
+            'code' => $this->beam->code,
+            'account' => app(Generator::class)->public_key(),
+            'signature' => '',
+        ]);
+        $this->assertTrue($response);
+    }
+
+    public function test_it_cannot_claim_transfer_token_with_frozen_collection()
+    {
+        $this->seedBeam(1, false, BeamType::TRANSFER_TOKEN);
+        $this->collection->update(['is_frozen' => true]);
+        $event = Frozen::fromChain([
+            'phase' => ['ApplyExtrinsic' => 1],
+            'event' => [
+                'MultiTokens' => [
+                    'Frozen' => [
+                        'FreezeOf<T>' => [
+                            'collection_id' => $this->collection->collection_chain_id,
+                            'freeze_type' => ['Collection' => []],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        resolve(PauseBeam::class)->handle(new CollectionFrozen($event));
+        $this->assertTrue($this->beam->refresh()->hasFlag(BeamFlag::PAUSED));
+
+        $response = $this->graphql($this->method, [
+            'code' => $this->beam->code,
+            'account' => app(Generator::class)->public_key(),
+            'signature' => '',
+        ], true);
+        $this->assertArraySubset(
+            $response['error'],
+            ['code' => ['There are no more claims available.', 'The beam is paused.']]
+        );
+    }
+
+    public function test_it_can_claim_with_mint_on_demand_and_transfer_token_with_frozen_collection()
+    {
+        $this->seedBeam(2, false, BeamType::MINT_ON_DEMAND);
+        $this->claims->first()->update(['type' => BeamType::TRANSFER_TOKEN->name]);
+        $this->collection->update(['is_frozen' => true]);
+        $event = Frozen::fromChain([
+            'phase' => ['ApplyExtrinsic' => 1],
+            'event' => [
+                'MultiTokens' => [
+                    'Frozen' => [
+                        'FreezeOf<T>' => [
+                            'collection_id' => $this->collection->collection_chain_id,
+                            'freeze_type' => ['Collection' => []],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        resolve(PauseBeam::class)->handle(new CollectionFrozen($event));
+        $this->assertFalse($this->beam->refresh()->hasFlag(BeamFlag::PAUSED));
+
+        $response = $this->graphql($this->method, [
+            'code' => $this->beam->code,
+            'account' => app(Generator::class)->public_key(),
+            'signature' => '',
+        ]);
+        $this->assertTrue($response);
+
+        $response = $this->graphql($this->method, [
+            'code' => $this->beam->code,
+            'account' => app(Generator::class)->public_key(),
+            'signature' => '',
+        ], true);
+        $this->assertArraySubset(
+            $response['error'],
+            ['code' => ['There are no more claims available.']]
+        );
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced the claim query in `ClaimBeam` to handle frozen collections, allowing claims to be processed correctly based on the collection's state.
- Improved the `PauseBeam` listener to incorporate logic that checks for claim types before pausing beams, ensuring correct handling of beams with different claim types.
- Updated the `CanClaim` rule to adjust validation logic and remaining claims calculation when collections are frozen, ensuring accurate claim processing.
- Added comprehensive tests in `ClaimBeamTest` to verify the behavior of claims when collections are frozen, covering various scenarios and claim types.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClaimBeam.php</strong><dd><code>Enhance claim query to support frozen collections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Jobs/ClaimBeam.php

<li>Added a check for frozen collections in the claim query.<br> <li> Modified the claim query to handle frozen collections.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/108/files#diff-7d3aba416652164d8d70a96632010b3833033de1cd8b8bc965a72e135c8cc264">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PauseBeam.php</strong><dd><code>Improve beam pausing logic based on claim types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Listeners/PauseBeam.php

<li>Added logic to check for claim types before pausing beams.<br> <li> Improved handling of beams based on claim types.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/108/files#diff-c1dbc91698f5382e1315f07397a6900e34677ef8a40b0d27c8c4498767a15710">+23/-10</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CanClaim.php</strong><dd><code>Update claim validation for frozen collections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Rules/CanClaim.php

<li>Adjusted validation logic for claims with frozen collections.<br> <li> Updated remaining claims calculation for frozen collections.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/108/files#diff-2c15a74db77bf69b1b421f8c2518fe94df5a6341bea4efe221c593e5eca3bc80">+14/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClaimBeamTest.php</strong><dd><code>Add tests for claims with frozen collections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Feature/GraphQL/Mutations/ClaimBeamTest.php

<li>Added tests for claiming with frozen collections.<br> <li> Verified behavior for different claim types with frozen collections.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/108/files#diff-abca64f724b7b0de167a1249ce0190d78276834a2881f92efb066d6b1ae59d19">+103/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information