### PR TITLE
[PLA-2079] Fix single use code

### DIFF
--- a/src/Services/BeamService.php
+++ b/src/Services/BeamService.php
@@ -285,7 +285,7 @@ class BeamService
                 ->first()) {
                 throw new BeamException(__('enjin-platform-beam::error.beam_not_found', ['code' => $code]));
             }
-            $singleUseCode = $singleUse->claimCode;
+            $singleUseCode = $code;
             $code = $singleUse->beamCode;
         }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the `claim` method of `BeamService` where the `singleUseCode` was incorrectly assigned.
- Ensured that the `singleUseCode` is set directly from the input `code` for proper functionality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BeamService.php</strong><dd><code>Fix assignment of single-use code variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Services/BeamService.php

<li>Fixed assignment of <code>singleUseCode</code> to use the correct variable.<br> <li> Ensured <code>singleUseCode</code> is set to the input <code>code</code> instead of <code>claimCode</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/111/files#diff-ad61fe9557d8825aa83df9c1b4f43f366501cc39578bb179cc229a0defca6578">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information