### PR TITLE
[PLA-2080] Check for empty values

### DIFF
--- a/src/Support/ClaimProbabilities.php
+++ b/src/Support/ClaimProbabilities.php
@@ -50,9 +50,9 @@ class ClaimProbabilities
     /**
      * Get the probabilities for a code.
      */
-    public static function getProbabilities(string $code): array
+    public static function getProbabilities(?string $code): array
     {
-        return Cache::get(
+        return empty($code) ? [] : Cache::get(
             static::getCacheKey($code),
             static::getProbabilitiesFromDB($code)
         );


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a potential crash in the `getProbabilities` method by allowing the `code` parameter to be nullable and adding a check for empty values.
- Ensured that an empty array is returned when `code` is empty, preventing further processing and potential errors.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClaimProbabilities.php</strong><dd><code>Fix crash by handling empty code in getProbabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Support/ClaimProbabilities.php

<li>Modified <code>getProbabilities</code> method to accept nullable string.<br> <li> Added a check for empty <code>code</code> to return an empty array.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/112/files#diff-dd2a7ec83656c385b5ca99c874c940a4b28d25a33595355652002b52041ac4f8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information