### PR TITLE
[PLA-2082] Check collection validity

### DIFF
--- a/src/Jobs/DispatchCreateBeamClaimsJobs.php
+++ b/src/Jobs/DispatchCreateBeamClaimsJobs.php
@@ -12,6 +12,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 
 class DispatchCreateBeamClaimsJobs implements ShouldQueue
 {
@@ -38,6 +39,13 @@ class DispatchCreateBeamClaimsJobs implements ShouldQueue
     public function handle(): void
     {
         $beam = $this->beam->load('collection');
+        if (!$beam?->collection) {
+            Log::error('Beam collection not found', ['beam_id' => $beam->id]);
+
+            return;
+        }
+
+
         $tokens = collect($this->tokens);
 
         $tokens->chunk(1000)


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Added a check to ensure the beam collection exists before proceeding with job execution.
- Implemented logging to capture errors when the beam collection is not found, aiding in debugging and error tracking.
- Introduced an early return to prevent further execution if the beam collection is missing, enhancing the robustness of the job handling.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DispatchCreateBeamClaimsJobs.php</strong><dd><code>Add logging and validation for beam collection existence</code>&nbsp; </dd></summary>
<hr>

src/Jobs/DispatchCreateBeamClaimsJobs.php

<li>Added logging for missing beam collection.<br> <li> Implemented early return if beam collection is not found.<br>


</details>


  </td>
  <td><a href="https://github.com/enjin/platform-beam/pull/113/files#diff-3cb54ec433f72a0bd5efc661de07c243f510f6a4ea37b570d2439b58bb986e42">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information